### PR TITLE
Remove hard-coded version definition

### DIFF
--- a/build_artifacts.sh
+++ b/build_artifacts.sh
@@ -6,6 +6,11 @@ fi
 
 GO_IMAGE=${GO_IMAGE:-golang:1.15.0}
 
+if [ "$KOOL_VERSION" == "" ]; then
+    echo "missing environment variable KOOL_VERSION"
+    exit 5
+fi
+
 rm -rf dist
 mkdir -p dist
 
@@ -26,7 +31,7 @@ for i in "${!BUILD[@]}"; do
         --env CGO_ENABLED=0 \
         -v $(pwd):/code -w /code $GO_IMAGE \
         go build -a -tags 'osusergo netgo static_build' \
-        -ldflags '-extldflags "-static"' \
+        -ldflags '-X kool-dev/kool/cmd.version='$KOOL_VERSION' -extldflags "-static"' \
         -o $dist
 done
 
@@ -34,7 +39,7 @@ echo "Building kool-install.exe"
 
 docker run --rm -i \
     -v $(pwd):/work \
-    amake/innosetup /dApplicationVersion=1.0.16 inno-setup/kool.iss
+    amake/innosetup /dApplicationVersion=$KOOL_VERSION inno-setup/kool.iss
 mv inno-setup/Output/mysetup.exe dist/kool-install.exe
 
 echo "Going to generate CHECKSUMS"

--- a/build_artifacts.sh
+++ b/build_artifacts.sh
@@ -9,33 +9,36 @@ GO_IMAGE=${GO_IMAGE:-golang:1.15.0}
 rm -rf dist
 mkdir -p dist
 
-echo "Building to GOOS=darwin GOARCH=amd64"
+BUILD=( \
+  "dist/kool-darwin-x86_64|--env GOOS=darwin --env GOARCH=amd64" \
+  "dist/kool-linux-x86_64|--env GOOS=linux --env GOARCH=amd64" \
+  "dist/kool-linux-arm6|--env GOOS=linux --env GOARCH=arm --env GOARM=6" \
+  "dist/kool-linux-arm7|--env GOOS=linux --env GOARCH=arm --env GOARM=7" \
+  "dist/kool.exe|--env GOOS=windows --env GOARCH=amd64" \
+)
 
-docker run --rm --env GOOS=darwin --env GOARCH=amd64 --env CGO_ENABLED=0 -v $(pwd):/code -w /code $GO_IMAGE go build -a -tags 'osusergo netgo static_build' -ldflags '-extldflags "-static"' -o dist/kool-darwin-x86_64
-
-echo "Building to GOOS=linux GOARCH=amd64"
-
-docker run --rm --env GOOS=linux --env GOARCH=amd64 --env CGO_ENABLED=0 -v $(pwd):/code -w /code $GO_IMAGE go build -a -tags 'osusergo netgo static_build' -ldflags '-extldflags "-static"' -o dist/kool-linux-x86_64
-
-echo "Building to GOOS=linux GOARCH=arm GOARM=6"
-
-docker run --rm --env GOOS=linux --env GOARCH=arm --env GOARM=6 --env CGO_ENABLED=0 -v $(pwd):/code -w /code $GO_IMAGE go build -a -tags 'osusergo netgo static_build' -ldflags '-extldflags "-static"' -o dist/kool-linux-arm6
-
-echo "Building to GOOS=linux GOARCH=arm GOARM=7"
-
-docker run --rm --env GOOS=linux --env GOARCH=arm --env GOARM=7 --env CGO_ENABLED=0 -v $(pwd):/code -w /code $GO_IMAGE go build -a -tags 'osusergo netgo static_build' -ldflags '-extldflags "-static"' -o dist/kool-linux-arm7
-
-echo "Building to GOOS=windows GOARCH=amd64"
-
-docker run --rm --env GOOS=windows --env GOARCH=amd64 --env CGO_ENABLED=0 -v $(pwd):/code -w /code $GO_IMAGE go build -a -tags 'osusergo netgo static_build' -ldflags '-extldflags "-static"' -o dist/kool.exe
+for i in "${!BUILD[@]}"; do
+    dist=$(echo ${BUILD[$i]} | cut -d'|' -f1)
+    flags=$(echo ${BUILD[$i]} | cut -d'|' -f2)
+    echo "Building to ${flags}"
+    docker run --rm \
+        $flags \
+        --env CGO_ENABLED=0 \
+        -v $(pwd):/code -w /code $GO_IMAGE \
+        go build -a -tags 'osusergo netgo static_build' \
+        -ldflags '-extldflags "-static"' \
+        -o $dist
+done
 
 echo "Building kool-install.exe"
 
-docker run --rm -i -v $(pwd):/work amake/innosetup /dApplicationVersion=1.0.16 inno-setup/kool.iss
+docker run --rm -i \
+    -v $(pwd):/work \
+    amake/innosetup /dApplicationVersion=1.0.16 inno-setup/kool.iss
 mv inno-setup/Output/mysetup.exe dist/kool-install.exe
 
 echo "Going to generate CHECKSUMS"
 
 for file in dist/*; do
-	shasum $file | awk '{print $1}' > $file.checksum
+    shasum $file | awk '{print $1}' > $file.checksum
 done

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,13 +4,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var version string = "undefined"
+
 var rootCmd = &cobra.Command{
 	Use:   "kool",
 	Short: "kool - Kool stuff",
 	Long: `An easy and robust software development environment
 tool helping you from project creation until deployment.
-Complete documentation is available at https://kool.dev`,
-	Version:           "1.0.16",
+Complete documentation is available at https://kool.dev/docs`,
+	Version:           version,
 	DisableAutoGenTag: true,
 }
 


### PR DESCRIPTION
https://github.com/kool-dev/kool/issues/32

Now in order to build a new version artefacts we must defined the KOOL_VERSION variable:

```bash
KOOL_VERSION=1.0.17 bash build_artifacts.sh
```