### PR TITLE
Removing print of command on run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,7 +54,6 @@ func runRun(cmd *cobra.Command, args []string) {
 			execArgs = append(execArgs, args[1:]...)
 		}
 
-		fmt.Println("$", exec[0], strings.Join(execArgs, " "))
 		err = shell.Interactive(exec[0], execArgs...)
 
 		if err != nil {


### PR DESCRIPTION
Currently when you use `kool run ...` it prints the command it will run by default, this breaks the new feature of output redirect.

We still have `KOOL_VERBOSE=1 kool run ...` in case you want to see the command it will run.