### PR TITLE
tests(start): adding tests to start command

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -23,8 +23,8 @@ var startCmdOutputWriter shell.OutputWriter = shell.NewOutputWriter()
 // NewStartCommand initializes new kool start command
 func NewStartCommand(startCmd *DefaultStartCmd) *cobra.Command {
 	return &cobra.Command{
-		Use:   "start",
-		Short: "Start Kool environment containers",
+		Use:   "start [service]",
+		Short: "Start the specified Kool environment containers. If no service is specified, start all.",
 		Run: func(cmd *cobra.Command, args []string) {
 			startCmdOutputWriter.SetWriter(cmd.OutOrStdout())
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,68 +1,70 @@
 package cmd
 
 import (
+	"kool-dev/kool/cmd/builder"
 	"kool-dev/kool/cmd/checker"
 	"kool-dev/kool/cmd/network"
 	"kool-dev/kool/cmd/shell"
-	"log"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
 
-// StartFlags holds the flags for the start command
-type StartFlags struct {
-	Services string
+// DefaultStartCmd holds interfaces for status command logic
+type DefaultStartCmd struct {
+	DependenciesChecker   checker.Checker
+	NetworkHandler        network.Handler
+	StartContainersRunner builder.Runner
+	Exiter                shell.Exiter
 }
 
-var startCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Start Kool environment containers",
-	Run:   runStart,
-}
+var startCmdOutputWriter shell.OutputWriter = shell.NewOutputWriter()
 
-var startFlags = &StartFlags{""}
+// NewStartCommand initializes new kool start command
+func NewStartCommand(startCmd *DefaultStartCmd) *cobra.Command {
+	return &cobra.Command{
+		Use:   "start",
+		Short: "Start Kool environment containers",
+		Run: func(cmd *cobra.Command, args []string) {
+			startCmdOutputWriter.SetWriter(cmd.OutOrStdout())
+
+			if err := startCmd.checkDependencies(); err != nil {
+				startCmdOutputWriter.ExecError("", err)
+				startCmd.Exiter.Exit(1)
+			}
+
+			startCmd.startContainers(args)
+		},
+	}
+}
 
 func init() {
-	rootCmd.AddCommand(startCmd)
-
-	startCmd.Flags().StringVarP(&startFlags.Services, "services", "", "", "Specific services to be started")
+	defaultStartCmd := &DefaultStartCmd{
+		checker.NewChecker(),
+		network.NewHandler(),
+		builder.NewCommand("docker-compose", "up", "-d", "--force-recreate"),
+		shell.NewExiter(),
+	}
+	rootCmd.AddCommand(NewStartCommand(defaultStartCmd))
 }
 
-func runStart(cmd *cobra.Command, args []string) {
-	var dependenciesChecker = checker.NewChecker()
-
-	if err := dependenciesChecker.VerifyDependencies(); err != nil {
-		shell.ExecError("", err)
-		os.Exit(1)
+func (s *DefaultStartCmd) checkDependencies() (err error) {
+	if err = s.DependenciesChecker.VerifyDependencies(); err != nil {
+		return
 	}
 
-	var globalNetworkHandler = network.NewHandler()
-
-	if err := globalNetworkHandler.HandleGlobalNetwork(os.Getenv("KOOL_GLOBAL_NETWORK")); err != nil {
-		log.Fatal(err)
+	if err = s.NetworkHandler.HandleGlobalNetwork(os.Getenv("KOOL_GLOBAL_NETWORK")); err != nil {
+		return
 	}
 
-	startContainers(startFlags.Services)
+	return
 }
 
-func startContainers(services string) {
-	var (
-		args []string
-		err  error
-	)
-
-	args = []string{"up", "-d", "--force-recreate"}
-
-	if services != "" {
-		args = append(args, strings.Split(services, " ")...)
-	}
-
-	err = shell.Interactive("docker-compose", args...)
+func (s *DefaultStartCmd) startContainers(services []string) {
+	err := s.StartContainersRunner.Interactive(services...)
 
 	if err != nil {
-		shell.ExecError("", err)
-		os.Exit(1)
+		startCmdOutputWriter.ExecError("", err)
+		s.Exiter.Exit(1)
 	}
 }

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+type FakeStartDependenciesChecker struct{}
+
+func (c *FakeStartDependenciesChecker) VerifyDependencies() (err error) {
+	return
+}
+
+type FakeStartFailedDependenciesChecker struct{}
+
+func (c *FakeStartFailedDependenciesChecker) VerifyDependencies() (err error) {
+	err = errors.New("dependencies")
+	return
+}
+
+type FakeStartNetworkHandler struct{}
+
+func (c *FakeStartNetworkHandler) HandleGlobalNetwork(networkName string) (err error) {
+	return
+}
+
+type FakeStartFailedNetworkHandler struct{}
+
+func (c *FakeStartFailedNetworkHandler) HandleGlobalNetwork(networkName string) (err error) {
+	err = errors.New("network")
+	return
+}
+
+type FakeStartRunner struct{}
+
+var startedServices []string
+
+func (c *FakeStartRunner) LookPath() (err error) {
+	return
+}
+
+func (c *FakeStartRunner) Interactive(args ...string) (err error) {
+	startedServices = []string{}
+	if len(args) > 0 {
+		startedServices = args
+	}
+	return
+}
+
+func (c *FakeStartRunner) Exec(args ...string) (outStr string, err error) {
+	return
+}
+
+var startExitCode int
+
+type FakeStartExiter struct{}
+
+func (e *FakeStartExiter) Exit(code int) {
+	startExitCode = code
+}
+
+func TestStartAllCommand(t *testing.T) {
+	defaultStartCmd := &DefaultStartCmd{
+		&FakeStartDependenciesChecker{},
+		&FakeStartNetworkHandler{},
+		&FakeStartRunner{},
+		&FakeStartExiter{},
+	}
+
+	cmd := NewStartCommand(defaultStartCmd)
+	startExitCode = 0
+
+	if _, err := execStartCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	if startExitCode != 0 {
+		t.Errorf("Expected no exit error, got '%v'", startExitCode)
+	}
+
+	if len(startedServices) > 0 {
+		t.Errorf("Expected no arguments, got '%v'", startedServices)
+	}
+}
+
+func TestStartServicesCommand(t *testing.T) {
+	defaultStartCmd := &DefaultStartCmd{
+		&FakeStartDependenciesChecker{},
+		&FakeStartNetworkHandler{},
+		&FakeStartRunner{},
+		&FakeStartExiter{},
+	}
+
+	cmd := NewStartCommand(defaultStartCmd)
+	startExitCode = 0
+	expected := []string{"app", "database"}
+	cmd.SetArgs(expected)
+
+	if _, err := execStartCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	if startExitCode != 0 {
+		t.Errorf("Expected no exit error, got '%v'", startExitCode)
+	}
+
+	if !startedServicesAreEqual(startedServices, expected) {
+		t.Errorf("Expect to start '%v', got '%v'", expected, startedServices)
+	}
+}
+
+func TestFailedDependenciesStartCommand(t *testing.T) {
+	defaultStartCmd := &DefaultStartCmd{
+		&FakeStartFailedDependenciesChecker{},
+		&FakeStartNetworkHandler{},
+		&FakeStartRunner{},
+		&FakeStartExiter{},
+	}
+
+	cmd := NewStartCommand(defaultStartCmd)
+	startExitCode = 0
+
+	_, err := execStartCommand(cmd)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if startExitCode != 1 {
+		t.Errorf("Expected an exit code 1, got '%v'", statusExitCode)
+	}
+}
+
+func TestFailedNetworkStartCommand(t *testing.T) {
+	defaultStartCmd := &DefaultStartCmd{
+		&FakeStartDependenciesChecker{},
+		&FakeStartFailedNetworkHandler{},
+		&FakeStartRunner{},
+		&FakeStartExiter{},
+	}
+
+	cmd := NewStartCommand(defaultStartCmd)
+	startExitCode = 0
+
+	_, err := execStartCommand(cmd)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if startExitCode != 1 {
+		t.Errorf("Expected an exit code 1, got '%v'", statusExitCode)
+	}
+}
+
+func execStartCommand(cmd *cobra.Command) (output string, err error) {
+	b := bytes.NewBufferString("")
+	cmd.SetOut(b)
+
+	if err = cmd.Execute(); err != nil {
+		return
+	}
+
+	var out []byte
+	if out, err = ioutil.ReadAll(b); err != nil {
+		return
+	}
+
+	output = strings.Trim(string(out), "\n")
+	return
+}
+
+func startedServicesAreEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -55,6 +55,15 @@ func (c *FakeStartRunner) Exec(args ...string) (outStr string, err error) {
 	return
 }
 
+type FakeFailedStartRunner struct {
+	FakeStartRunner
+}
+
+func (c *FakeFailedStartRunner) Interactive(args ...string) (err error) {
+	err = errors.New("")
+	return
+}
+
 var startExitCode int
 
 type FakeStartExiter struct{}
@@ -140,6 +149,28 @@ func TestFailedNetworkStartCommand(t *testing.T) {
 		&FakeStartDependenciesChecker{},
 		&FakeStartFailedNetworkHandler{},
 		&FakeStartRunner{},
+		&FakeStartExiter{},
+	}
+
+	cmd := NewStartCommand(defaultStartCmd)
+	startExitCode = 0
+
+	_, err := execStartCommand(cmd)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if startExitCode != 1 {
+		t.Errorf("Expected an exit code 1, got '%v'", statusExitCode)
+	}
+}
+
+func TestStartWithError(t *testing.T) {
+	defaultStartCmd := &DefaultStartCmd{
+		&FakeStartDependenciesChecker{},
+		&FakeStartNetworkHandler{},
+		&FakeFailedStartRunner{},
 		&FakeStartExiter{},
 	}
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -10,48 +10,48 @@ import (
 	"testing"
 )
 
-type FakeDependenciesChecker struct{}
+type FakeStatusDependenciesChecker struct{}
 
-func (c *FakeDependenciesChecker) VerifyDependencies() (err error) {
+func (c *FakeStatusDependenciesChecker) VerifyDependencies() (err error) {
 	return
 }
 
-type FakeFailedDependenciesChecker struct{}
+type FakeStatusFailedDependenciesChecker struct{}
 
-func (c *FakeFailedDependenciesChecker) VerifyDependencies() (err error) {
+func (c *FakeStatusFailedDependenciesChecker) VerifyDependencies() (err error) {
 	err = errors.New("")
 	return
 }
 
-type FakeNetworkHandler struct{}
+type FakeStatusNetworkHandler struct{}
 
-func (c *FakeNetworkHandler) HandleGlobalNetwork(networkName string) (err error) {
+func (c *FakeStatusNetworkHandler) HandleGlobalNetwork(networkName string) (err error) {
 	return
 }
 
-type FakeFailedNetworkHandler struct{}
+type FakeStatusFailedNetworkHandler struct{}
 
-func (c *FakeFailedNetworkHandler) HandleGlobalNetwork(networkName string) (err error) {
+func (c *FakeStatusFailedNetworkHandler) HandleGlobalNetwork(networkName string) (err error) {
 	err = errors.New("")
 	return
 }
 
-type FakeRunner struct{}
+type FakeStatusRunner struct{}
 
-func (c *FakeRunner) LookPath() (err error) {
+func (c *FakeStatusRunner) LookPath() (err error) {
 	return
 }
 
-func (c *FakeRunner) Interactive(args ...string) (err error) {
+func (c *FakeStatusRunner) Interactive(args ...string) (err error) {
 	return
 }
 
-func (c *FakeRunner) Exec(args ...string) (outStr string, err error) {
+func (c *FakeStatusRunner) Exec(args ...string) (outStr string, err error) {
 	return
 }
 
 type FakeGetServicesRunner struct {
-	FakeRunner
+	FakeStatusRunner
 }
 
 func (c *FakeGetServicesRunner) Exec(args ...string) (outStr string, err error) {
@@ -64,7 +64,7 @@ database
 }
 
 type FakeFailedGetServicesRunner struct {
-	FakeRunner
+	FakeStatusRunner
 }
 
 func (c *FakeFailedGetServicesRunner) Exec(args ...string) (outStr string, err error) {
@@ -73,7 +73,7 @@ func (c *FakeFailedGetServicesRunner) Exec(args ...string) (outStr string, err e
 }
 
 type FakeGetServiceIDRunner struct {
-	FakeRunner
+	FakeStatusRunner
 }
 
 func (c *FakeGetServiceIDRunner) Exec(args ...string) (outStr string, err error) {
@@ -82,7 +82,7 @@ func (c *FakeGetServiceIDRunner) Exec(args ...string) (outStr string, err error)
 }
 
 type FakeFailedGetServiceIDRunner struct {
-	FakeRunner
+	FakeStatusRunner
 }
 
 func (c *FakeFailedGetServiceIDRunner) Exec(args ...string) (outStr string, err error) {
@@ -91,7 +91,7 @@ func (c *FakeFailedGetServiceIDRunner) Exec(args ...string) (outStr string, err 
 }
 
 type FakeGetServiceStatusPortRunner struct {
-	FakeRunner
+	FakeStatusRunner
 }
 
 func (c *FakeGetServiceStatusPortRunner) Exec(args ...string) (outStr string, err error) {
@@ -100,7 +100,7 @@ func (c *FakeGetServiceStatusPortRunner) Exec(args ...string) (outStr string, er
 }
 
 type FakeNotRunningGetServiceStatusPortRunner struct {
-	FakeRunner
+	FakeStatusRunner
 }
 
 func (c *FakeNotRunningGetServiceStatusPortRunner) Exec(args ...string) (outStr string, err error) {
@@ -108,22 +108,22 @@ func (c *FakeNotRunningGetServiceStatusPortRunner) Exec(args ...string) (outStr 
 	return
 }
 
-var exitCode int
+var statusExitCode int
 
-type FakeExiter struct{}
+type FakeStatusExiter struct{}
 
-func (e *FakeExiter) Exit(code int) {
-	exitCode = code
+func (e *FakeStatusExiter) Exit(code int) {
+	statusExitCode = code
 }
 
 func TestStatusCommand(t *testing.T) {
 	defaultStatusCmd := &DefaultStatusCmd{
-		&FakeDependenciesChecker{},
-		&FakeNetworkHandler{},
+		&FakeStatusDependenciesChecker{},
+		&FakeStatusNetworkHandler{},
 		&FakeGetServicesRunner{},
 		&FakeGetServiceIDRunner{},
 		&FakeGetServiceStatusPortRunner{},
-		&FakeExiter{},
+		&FakeStatusExiter{},
 	}
 	cmd := NewStatusCommand(defaultStatusCmd)
 	output, err := execStatusCommand(cmd)
@@ -142,7 +142,6 @@ func TestStatusCommand(t *testing.T) {
 +----------+---------+------------------------------+------------------+
 `
 	expected = strings.Trim(expected, "\n")
-	output = strings.Trim(output, "\n")
 
 	if output != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, output)
@@ -151,12 +150,12 @@ func TestStatusCommand(t *testing.T) {
 
 func TestNotRunningStatusCommand(t *testing.T) {
 	defaultStatusCmd := &DefaultStatusCmd{
-		&FakeDependenciesChecker{},
-		&FakeNetworkHandler{},
+		&FakeStatusDependenciesChecker{},
+		&FakeStatusNetworkHandler{},
 		&FakeGetServicesRunner{},
 		&FakeGetServiceIDRunner{},
 		&FakeNotRunningGetServiceStatusPortRunner{},
-		&FakeExiter{},
+		&FakeStatusExiter{},
 	}
 	cmd := NewStatusCommand(defaultStatusCmd)
 	output, err := execStatusCommand(cmd)
@@ -175,7 +174,6 @@ func TestNotRunningStatusCommand(t *testing.T) {
 +----------+-------------+-------+--------------------+
 `
 	expected = strings.Trim(expected, "\n")
-	output = strings.Trim(output, "\n")
 
 	if output != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, output)
@@ -184,12 +182,12 @@ func TestNotRunningStatusCommand(t *testing.T) {
 
 func TestNoStatusPortStatusCommand(t *testing.T) {
 	defaultStatusCmd := &DefaultStatusCmd{
-		&FakeDependenciesChecker{},
-		&FakeNetworkHandler{},
+		&FakeStatusDependenciesChecker{},
+		&FakeStatusNetworkHandler{},
 		&FakeGetServicesRunner{},
 		&FakeGetServiceIDRunner{},
-		&FakeRunner{},
-		&FakeExiter{},
+		&FakeStatusRunner{},
+		&FakeStatusExiter{},
 	}
 	cmd := NewStatusCommand(defaultStatusCmd)
 	output, err := execStatusCommand(cmd)
@@ -208,7 +206,6 @@ func TestNoStatusPortStatusCommand(t *testing.T) {
 +----------+-------------+-------+-------+
 `
 	expected = strings.Trim(expected, "\n")
-	output = strings.Trim(output, "\n")
 
 	if output != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, output)
@@ -217,12 +214,12 @@ func TestNoStatusPortStatusCommand(t *testing.T) {
 
 func TestNoServicesStatusCommand(t *testing.T) {
 	defaultStatusCmd := &DefaultStatusCmd{
-		&FakeDependenciesChecker{},
-		&FakeNetworkHandler{},
-		&FakeRunner{},
+		&FakeStatusDependenciesChecker{},
+		&FakeStatusNetworkHandler{},
+		&FakeStatusRunner{},
 		&FakeGetServiceIDRunner{},
 		&FakeGetServiceStatusPortRunner{},
-		&FakeExiter{},
+		&FakeStatusExiter{},
 	}
 	cmd := NewStatusCommand(defaultStatusCmd)
 	output, err := execStatusCommand(cmd)
@@ -232,7 +229,6 @@ func TestNoServicesStatusCommand(t *testing.T) {
 	}
 
 	expected := color.New(color.Yellow).Sprint("No services found.")
-	output = strings.Trim(output, "\n")
 
 	if output != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, output)
@@ -241,12 +237,12 @@ func TestNoServicesStatusCommand(t *testing.T) {
 
 func TestFailedGetServicesStatusCommand(t *testing.T) {
 	defaultStatusCmd := &DefaultStatusCmd{
-		&FakeDependenciesChecker{},
-		&FakeNetworkHandler{},
+		&FakeStatusDependenciesChecker{},
+		&FakeStatusNetworkHandler{},
 		&FakeFailedGetServicesRunner{},
 		&FakeGetServiceIDRunner{},
 		&FakeGetServiceStatusPortRunner{},
-		&FakeExiter{},
+		&FakeStatusExiter{},
 	}
 	cmd := NewStatusCommand(defaultStatusCmd)
 	output, err := execStatusCommand(cmd)
@@ -256,7 +252,6 @@ func TestFailedGetServicesStatusCommand(t *testing.T) {
 	}
 
 	expected := color.New(color.Yellow).Sprint("No services found.")
-	output = strings.Trim(output, "\n")
 
 	if output != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, output)
@@ -265,15 +260,15 @@ func TestFailedGetServicesStatusCommand(t *testing.T) {
 
 func TestFailedDependenciesStatusCommand(t *testing.T) {
 	defaultStatusCmd := &DefaultStatusCmd{
-		&FakeFailedDependenciesChecker{},
-		&FakeNetworkHandler{},
+		&FakeStatusFailedDependenciesChecker{},
+		&FakeStatusNetworkHandler{},
 		&FakeGetServicesRunner{},
 		&FakeGetServiceIDRunner{},
 		&FakeGetServiceStatusPortRunner{},
-		&FakeExiter{},
+		&FakeStatusExiter{},
 	}
 	cmd := NewStatusCommand(defaultStatusCmd)
-	exitCode = 0
+	statusExitCode = 0
 
 	_, err := execStatusCommand(cmd)
 
@@ -281,22 +276,22 @@ func TestFailedDependenciesStatusCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if exitCode != 1 {
-		t.Errorf("Expected an exit code 1, got '%v'", exitCode)
+	if statusExitCode != 1 {
+		t.Errorf("Expected an exit code 1, got '%v'", statusExitCode)
 	}
 }
 
 func TestFailedNetworkStatusCommand(t *testing.T) {
 	defaultStatusCmd := &DefaultStatusCmd{
-		&FakeDependenciesChecker{},
-		&FakeFailedNetworkHandler{},
+		&FakeStatusDependenciesChecker{},
+		&FakeStatusFailedNetworkHandler{},
 		&FakeGetServicesRunner{},
 		&FakeGetServiceIDRunner{},
 		&FakeGetServiceStatusPortRunner{},
-		&FakeExiter{},
+		&FakeStatusExiter{},
 	}
 	cmd := NewStatusCommand(defaultStatusCmd)
-	exitCode = 0
+	statusExitCode = 0
 
 	_, err := execStatusCommand(cmd)
 
@@ -304,22 +299,22 @@ func TestFailedNetworkStatusCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if exitCode != 1 {
-		t.Errorf("Expected an exit code 1, got '%v'", exitCode)
+	if statusExitCode != 1 {
+		t.Errorf("Expected an exit code 1, got '%v'", statusExitCode)
 	}
 }
 
 func TestFailedGetServiceIDStatusCommand(t *testing.T) {
 	defaultStatusCmd := &DefaultStatusCmd{
-		&FakeDependenciesChecker{},
-		&FakeNetworkHandler{},
+		&FakeStatusDependenciesChecker{},
+		&FakeStatusNetworkHandler{},
 		&FakeGetServicesRunner{},
 		&FakeFailedGetServiceIDRunner{},
 		&FakeGetServiceStatusPortRunner{},
-		&FakeExiter{},
+		&FakeStatusExiter{},
 	}
 	cmd := NewStatusCommand(defaultStatusCmd)
-	exitCode = 0
+	statusExitCode = 0
 
 	_, err := execStatusCommand(cmd)
 
@@ -327,8 +322,8 @@ func TestFailedGetServiceIDStatusCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if exitCode != 1 {
-		t.Errorf("Expected an exit code 1, got '%v'", exitCode)
+	if statusExitCode != 1 {
+		t.Errorf("Expected an exit code 1, got '%v'", statusExitCode)
 	}
 }
 
@@ -345,6 +340,6 @@ func execStatusCommand(cmd *cobra.Command) (output string, err error) {
 		return
 	}
 
-	output = string(out)
+	output = strings.Trim(string(out), "\n")
 	return
 }

--- a/docs/4-Commands/0-kool.md
+++ b/docs/4-Commands/0-kool.md
@@ -22,7 +22,7 @@ Complete documentation is available at https://kool.dev/docs
 * [kool logs](kool-logs.md)	 - Displays log output from services.
 * [kool run](kool-run.md)	 - Runs a custom command defined at kool.yaml in the working directory or in the kool folder of the user's home directory
 * [kool self-update](kool-self-update.md)	 - Update kool to latest version
-* [kool start](kool-start.md)	 - Start Kool environment containers
+* [kool start](kool-start.md)	 - Start the specified Kool environment containers. If no service is specified, start all.
 * [kool status](kool-status.md)	 - Shows the status for containers
 * [kool stop](kool-stop.md)	 - Stop kool environment containers
 

--- a/docs/4-Commands/kool-start.md
+++ b/docs/4-Commands/kool-start.md
@@ -1,20 +1,19 @@
 ## kool start
 
-Start Kool environment containers
+Start the specified Kool environment containers. If no service is specified, start all.
 
 ### Synopsis
 
-Start Kool environment containers
+Start the specified Kool environment containers. If no service is specified, start all.
 
 ```
-kool start [flags]
+kool start [service] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help              help for start
-      --services string   Specific services to be started
+  -h, --help   help for start
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Relates to #20 

Also removing the services flags and adding them as arguments to the command, as discussed on #87 