### PR TITLE
change presets to avoid init

### DIFF
--- a/cmd/presets/presets.go
+++ b/cmd/presets/presets.go
@@ -1,14 +1,9 @@
 package presets
 
 // auto generated file
-
-var presets = make(map[string]map[string]string) //nolint
-
 // GetAll get all presets
 func GetAll() map[string]map[string]string {
-	return presets
-}
-func init() {
+	var presets = make(map[string]map[string]string)
 	presets["adonis"] = map[string]string{
 		"Dockerfile.build": `FROM kooldev/node:14-adonis AS build
 
@@ -576,4 +571,5 @@ networks:
   mysql: kool exec database mysql -uroot -p$DB_PASSWORD
   mysql-no-tty: kool exec --disable-tty database mysql -uroot -p$DB_PASSWORD`,
 	}
+	return presets
 }

--- a/cmd/presets/presets_test.go
+++ b/cmd/presets/presets_test.go
@@ -1,14 +1,15 @@
 package presets
 
 import (
-	"gopkg.in/yaml.v2"
 	"kool-dev/kool/cmd/builder"
 	"kool-dev/kool/cmd/parser"
 	"testing"
+
+	"gopkg.in/yaml.v2"
 )
 
 func TestPresetsKoolFile(t *testing.T) {
-	for preset, files := range presets {
+	for preset, files := range GetAll() {
 		var (
 			parsed *parser.KoolYaml
 			kool   []byte

--- a/parse_presets.sh
+++ b/parse_presets.sh
@@ -2,7 +2,9 @@
 
 cp templates/presets_template.go cmd/presets/presets.go
 
-echo "func init() {" >> cmd/presets/presets.go
+echo "// GetAll get all presets" >> cmd/presets/presets.go
+echo "func GetAll() map[string]map[string]string {" >> cmd/presets/presets.go
+echo "	var presets = make(map[string]map[string]string)" >> cmd/presets/presets.go
 
 for folder in presets/*/; do
     if [ ! -d $folder ]; then
@@ -25,6 +27,7 @@ for folder in presets/*/; do
 	echo "	}" >> cmd/presets/presets.go
 done
 
+echo "	return presets" >> cmd/presets/presets.go
 echo "}" >> cmd/presets/presets.go
 
 echo "Finished building cmd/presets/presets.go"

--- a/templates/presets_template.go
+++ b/templates/presets_template.go
@@ -1,10 +1,3 @@
 package presets
 
 // auto generated file
-
-var presets = make(map[string]map[string]string) //nolint
-
-// GetAll get all presets
-func GetAll() map[string]map[string]string {
-	return presets
-}


### PR DESCRIPTION
This is an minor improvement... `init()` is executed before `main()`, therefore it adds up overhead to ANY execution...

Not using `init()` on stuff that we DO NOT NEED to execute every single time, is a minor optimisation and good practice we can try to follow.