### PR TITLE
Fix UID Windows

### DIFF
--- a/build_artifacts.sh
+++ b/build_artifacts.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version )
+      KOOL_VERSION="$2"
+      shift 2
+      ;;
+    -- )
+      shift
+      break
+      ;;
+    *)
+      echo "Invalid Argument: ${1}"
+      exit 1
+      ;;
+  esac
+done
+
 if [ -f .env ]; then
     source .env
 fi

--- a/environment/asuser.go
+++ b/environment/asuser.go
@@ -2,13 +2,8 @@
 
 package environment
 
-import (
-	"fmt"
-	"os"
-)
-
 func initAsuser(envStorage EnvStorage) {
 	if envStorage.Get("KOOL_ASUSER") == "" {
-		envStorage.Set("KOOL_ASUSER", fmt.Sprintf("%d", os.Getuid()))
+		envStorage.Set("KOOL_ASUSER", uid())
 	}
 }

--- a/environment/asuser_test_windows.go
+++ b/environment/asuser_test_windows.go
@@ -1,0 +1,25 @@
+package environment
+
+import (
+	"testing"
+)
+
+func TestInitAsuser(t *testing.T) {
+	f := NewFakeEnvStorage()
+	initAsuser(f)
+
+	if f.Envs["KOOL_ASUSER"] != uid() {
+		t.Error("failed setting current user to KOOL_ASUSER")
+	}
+}
+
+func TestAlreadyExistingKoolUserInitAsuser(t *testing.T) {
+	f := NewFakeEnvStorage()
+	f.Envs["KOOL_ASUSER"] = "testing_user"
+
+	initAsuser(f)
+
+	if f.Envs["KOOL_ASUSER"] != uid() {
+		t.Error("failed setting current user to KOOL_ASUSER")
+	}
+}

--- a/environment/asuser_windows.go
+++ b/environment/asuser_windows.go
@@ -3,5 +3,5 @@ package environment
 func initAsuser(envStorage EnvStorage) {
 	// under native windows defaults to using
 	// root inside containers for kool managed images
-	envStorage.Set("KOOL_ASUSER", "0")
+	envStorage.Set("KOOL_ASUSER", uid())
 }

--- a/environment/env.go
+++ b/environment/env.go
@@ -1,7 +1,6 @@
 package environment
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -28,9 +27,8 @@ func InitEnvironmentVariables(envStorage EnvStorage, defaultEnvValues string) {
 	if envStorage.Get("HOME") == "" {
 		envStorage.Set("HOME", homeDir)
 	}
-	if envStorage.Get("UID") == "" {
-		envStorage.Set("UID", fmt.Sprintf("%d", os.Getuid()))
-	}
+
+	initUid(envStorage)
 
 	if envStorage.Get("PWD") == "" {
 		workDir, err = os.Getwd()

--- a/environment/env_test.go
+++ b/environment/env_test.go
@@ -1,7 +1,6 @@
 package environment
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -28,7 +27,7 @@ func TestInitEnvironmentVariables(t *testing.T) {
 		t.Errorf("expecting $HOME value '%s', got '%s'", homeDir, envHomeDir)
 	}
 
-	UID := fmt.Sprintf("%d", os.Getuid())
+	UID := uid()
 
 	if envUID := f.Envs["UID"]; envUID != UID {
 		t.Errorf("expecting $UID value '%s', got '%s'", UID, envUID)

--- a/environment/uid.go
+++ b/environment/uid.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package environment
+
+import (
+	"fmt"
+	"os"
+)
+
+func initUid(envStorage EnvStorage) {
+	if envStorage.Get("UID") == "" {
+		envStorage.Set("UID", uid())
+	}
+}
+
+func uid() string {
+	return fmt.Sprintf("%d", os.Getuid())
+}

--- a/environment/uid_test.go
+++ b/environment/uid_test.go
@@ -1,0 +1,29 @@
+// +build !windows
+
+package environment
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestInitUid(t *testing.T) {
+	f := NewFakeEnvStorage()
+	initUid(f)
+
+	if f.Envs["UID"] != fmt.Sprintf("%d", os.Getuid()) {
+		t.Error("failed setting current uid to KOOL_ASUSER")
+	}
+}
+
+func TestAlreadyExistingKoolUserInitUid(t *testing.T) {
+	f := NewFakeEnvStorage()
+	f.Envs["UID"] = "1000"
+
+	initUid(f)
+
+	if f.Envs["UID"] != "1000" {
+		t.Error("should not set new uid if it is already set")
+	}
+}

--- a/environment/uid_test_windows.go
+++ b/environment/uid_test_windows.go
@@ -1,10 +1,6 @@
-// +build !windows
-
 package environment
 
 import (
-	"fmt"
-	"os"
 	"testing"
 )
 
@@ -12,7 +8,7 @@ func TestInitUid(t *testing.T) {
 	f := NewFakeEnvStorage()
 	initUid(f)
 
-	if f.Envs["UID"] != fmt.Sprintf("%d", os.Getuid()) {
+	if f.Envs["UID"] != uid() {
 		t.Error("failed setting current uid to UID")
 	}
 }
@@ -23,7 +19,7 @@ func TestAlreadyExistingKoolUserInitUid(t *testing.T) {
 
 	initUid(f)
 
-	if f.Envs["UID"] != "1000" {
+	if f.Envs["UID"] != uid() {
 		t.Error("should not set new uid if it is already set")
 	}
 }

--- a/environment/uid_windows.go
+++ b/environment/uid_windows.go
@@ -1,0 +1,25 @@
+package environment
+
+import (
+	"os/user"
+	"regexp"
+)
+
+var sidExp = regexp.MustCompile(`([\d\D]+-)(?P<uid>\d+)`)
+
+func initUid(envStorage EnvStorage) {
+	// under native windows defaults to using
+	// root inside containers for kool managed images
+	envStorage.Set("UID", uid())
+}
+
+func uid() string {
+	current, _ := user.Current()
+	match := sidExp.FindStringSubmatch(current.Uid)
+
+	results := map[string]string{}
+	for i, name := range match {
+		results[sidExp.SubexpNames()[i]] = name
+	}
+	return results["uid"]
+}

--- a/environment/uid_windows.go
+++ b/environment/uid_windows.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 )
 
-var sidExp = regexp.MustCompile(`([\d\D]+-)(?P<uid>\d+)`)
+var sidExp = regexp.MustCompile(`.*-(?P<uid>\d+)`)
 
 func initUid(envStorage EnvStorage) {
 	// under native windows defaults to using
@@ -21,5 +21,10 @@ func uid() string {
 	for i, name := range match {
 		results[sidExp.SubexpNames()[i]] = name
 	}
-	return results["uid"]
+
+	if uid, ok := results["uid"]; ok {
+		return uid
+	}
+
+	return "0"
 }

--- a/environment/uid_windows_test.go
+++ b/environment/uid_windows_test.go
@@ -1,0 +1,19 @@
+package environment
+
+import (
+	"os/user"
+	"testing"
+)
+
+func TestUid(t *testing.T) {
+	current, _ := user.Current()
+
+	if "0" != uid() {
+		t.Errorf("expecting $UID value '%s', got '%s'", uid(), "0")
+	}
+
+	current.Uid = ""
+	if "0" == uid() {
+		t.Errorf("expecting $UID value '%s', got '%s'", "0", uid())
+	}
+}

--- a/environment/uid_windows_test.go
+++ b/environment/uid_windows_test.go
@@ -8,12 +8,12 @@ import (
 func TestUid(t *testing.T) {
 	current, _ := user.Current()
 
-	if "0" != uid() {
+	if "0" == uid() {
 		t.Errorf("expecting $UID value '%s', got '%s'", uid(), "0")
 	}
 
 	current.Uid = ""
-	if "0" == uid() {
+	if "0" != uid() {
 		t.Errorf("expecting $UID value '%s', got '%s'", "0", uid())
 	}
 }

--- a/environment/uid_windows_test.go
+++ b/environment/uid_windows_test.go
@@ -1,19 +1,18 @@
 package environment
 
 import (
-	"os/user"
 	"testing"
 )
 
 func TestUid(t *testing.T) {
-	current, _ := user.Current()
-
 	if "0" == uid() {
 		t.Errorf("expecting $UID value '%s', got '%s'", uid(), "0")
 	}
 
-	current.Uid = ""
-	if "0" != uid() {
-		t.Errorf("expecting $UID value '%s', got '%s'", "0", uid())
-	}
+	// TODO Find a way to test, user.Current uses cache so it didn't work to change
+	//current, _ := user.Current()
+	//current.Uid = ""
+	//if "0" != uid() {
+	//	t.Errorf("expecting $UID value '%s', got '%s'", "0", uid())
+	//}
 }

--- a/inno-setup/kool.iss
+++ b/inno-setup/kool.iss
@@ -43,9 +43,6 @@ Name: en; MessagesFile: "compiler:Default.isl"
 Source: "..\dist\kool.exe"; DestDir: "{autopf}\{#ApplicationGroup}\bin"; Flags: ignoreversion
 Source: "kool.ico"; DestDir: "{autopf}\{#ApplicationGroup}"; Flags: ignoreversion
 
-[Registry]
-Root: HKLM; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "APPLICATION_NAME"; ValueData: "{autopf}\{#ApplicationGroup}\bin\kool.exe"; Flags: uninsdeletevalue
-
 [Code]
 procedure CurStepChanged(CurStep: TSetupStep);
 begin


### PR DESCRIPTION
Correction of generating uid for Windows and installing does not add kool on Windows startup.

- As in Windows we don't have uid, use sid and get the last number, example: S-1-5-21-3623811015-3361044348-30300820-1013
 So, in this case, the uid used is 1013, this solve the problem to use root,  but it still has problems as in other cases that we saw in linux in docker images
 - Fix the installer was putting the kool to boot with windows start
 - Add arguments to build_artifacts, sample: `./build_artifacts.sh --version 1.6.0`