### PR TITLE
feat(init): deprecating init command

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "github.com/gookit/color"
+
+func init() {
+	initCmd := NewPresetCommand(NewKoolPreset())
+	initCmd.Use = "init [PRESET]"
+	initCmd.Short = "[DEPRECATED] Proxies preset command"
+	initCmd.Deprecated = color.New(color.Yellow).Sprint("use the \"preset\" command instead.")
+
+	rootCmd.AddCommand(initCmd)
+}

--- a/docs/4-Commands/0-kool.md
+++ b/docs/4-Commands/0-kool.md
@@ -19,6 +19,7 @@ Complete documentation is available at https://kool.dev/docs
 * [kool docker](kool-docker.md)	 - Creates a new container and runs the command in it.
 * [kool exec](kool-exec.md)	 - Execute a command within a running service container
 * [kool info](kool-info.md)	 - Prints out information about kool setup (like environment variables)
+* [kool init](kool-init.md)	 - [DEPRECATED] Proxies preset command
 * [kool logs](kool-logs.md)	 - Displays log output from services.
 * [kool preset](kool-preset.md)	 - Initialize kool preset in the current working directory. If no preset argument is specified you will be prompted to pick among the existing options.
 * [kool restart](kool-restart.md)	 - Restart containers - the same as stop followed by start.

--- a/docs/4-Commands/kool-init.md
+++ b/docs/4-Commands/kool-init.md
@@ -1,0 +1,25 @@
+## kool init
+
+[DEPRECATED] Initialize kool preset in the current working directory. If no preset argument is specified you will be prompted to pick among the existing options.
+
+```
+kool init [PRESET] [flags]
+```
+
+### Options
+
+```
+  -h, --help       help for init
+      --override   Force replace local existing files with the preset files
+```
+
+### Options inherited from parent commands
+
+```
+      --verbose   increases output verbosity
+```
+
+### SEE ALSO
+
+* [kool](kool.md)	 - kool - Kool stuff
+


### PR DESCRIPTION
Relates to #11 

This pull request brings back the init command, but deprecated and working as a proxy to the preset command, in case we need to release a new tag before `2.0.0`