### PR TITLE
routing internally kool commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
+	"kool-dev/kool/cmd/shell"
 	"kool-dev/kool/environment"
+
+	"github.com/spf13/cobra"
 )
 
 // CobraRunFN Cobra command run function
@@ -35,6 +37,11 @@ Complete documentation is available at https://kool.dev/docs`,
 
 // Execute proxies the call to cobra root command
 func Execute() error {
+	shell.RecursiveCall = func(args []string) error {
+		rootCmd.SetArgs(args)
+		return rootCmd.Execute()
+	}
+
 	return rootCmd.Execute()
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -246,7 +246,7 @@ func TestRecursiveCall(t *testing.T) {
 	recursive := &cobra.Command{
 		Use: "recursive",
 		Run: func(cmd *cobra.Command, args []string) {
-			shell.Interactive("kool", "-v")
+			_ = shell.Interactive("kool", "-v")
 		},
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"kool-dev/kool/cmd/shell"
 	"kool-dev/kool/environment"
 	"os"
 	"strings"
@@ -238,5 +239,24 @@ func TestVerboseFlagRootCommand(t *testing.T) {
 
 	if verbose := fakeEnv.IsTrue("KOOL_VERBOSE"); !verbose {
 		t.Error("expecting 'KOOL_VERBOSE' to be true, got false")
+	}
+}
+
+func TestRecursiveCall(t *testing.T) {
+	recursive := &cobra.Command{
+		Use: "recursive",
+		Run: func(cmd *cobra.Command, args []string) {
+			shell.Interactive("kool", "-v")
+		},
+	}
+
+	rootCmd.AddCommand(recursive)
+
+	rootCmd.SetArgs([]string{"recursive"})
+
+	err := Execute()
+
+	if err != nil {
+		t.Errorf("fail calling recursive command: %v", err)
 	}
 }

--- a/cmd/shell/shell_test.go
+++ b/cmd/shell/shell_test.go
@@ -381,6 +381,11 @@ func TestRecursiveInteractiveCommand(t *testing.T) {
 		calledRecursiveArgs []string
 	)
 
+	oldRecursiveCall := RecursiveCall
+	defer func() {
+		RecursiveCall = oldRecursiveCall
+	}()
+
 	// set published RecursiveCall handler
 	RecursiveCall = func(args []string) error {
 		calledRecursive = true

--- a/cmd/shell/shell_test.go
+++ b/cmd/shell/shell_test.go
@@ -371,3 +371,30 @@ func TestSuccessShell(t *testing.T) {
 		t.Errorf("expecting output '%s', got '%s'", expected, output)
 	}
 }
+
+func TestRecursiveInteractiveCommand(t *testing.T) {
+	s := NewShell()
+	command := builder.NewCommand("kool", "-v")
+
+	var (
+		calledRecursive     = false
+		calledRecursiveArgs []string
+	)
+
+	// set published RecursiveCall handler
+	RecursiveCall = func(args []string) error {
+		calledRecursive = true
+		calledRecursiveArgs = args
+		return nil
+	}
+
+	err := s.Interactive(command)
+
+	if err != nil {
+		t.Errorf("unexpected error calling recursive kool: %s", err.Error())
+	}
+
+	if !calledRecursive || len(calledRecursiveArgs) != 1 || calledRecursiveArgs[0] != "-v" {
+		t.Errorf("unexpected recursive call - args: %v", calledRecursiveArgs)
+	}
+}


### PR DESCRIPTION
This PR aims at optimizing a little bit the usual case where `kool` needs to execute other `kool` commands due to aliases usage on `kool.yml` files.

This is only targeted at `shell.Interactive()` commands as the `Execute()` requires the output, so this is not implemented at this point (we can look into it other time).