### PR TITLE
add grype docker image scanning

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,13 @@ jobs:
         TAGNAME: ${{ steps.tagName.outputs.tag }}
       run: docker run kooldev/kool:$TAGNAME kool --version
 
+    - name: Scan image
+      uses: anchore/scan-action@v2
+      with:
+        image: "kooldev/kool:$TAGNAME"
+        fail-build: true
+        severity-cutoff: critical
+
     - name: Push to hub
       env:
         TAGNAME: ${{ steps.tagName.outputs.tag }}


### PR DESCRIPTION

- Adding [`grype`](https://github.com/anchore/grype)

:new: Other

#### TL;DR

`grype` aims at finding known vulnerabilities in Docker images. Security practices that we should pursue every more often.

---

#### Describe the update

Have added new step on `docker` GH action for checking for vulnerabilities.

![image](https://user-images.githubusercontent.com/1116377/106347385-c2598900-629c-11eb-9486-fece80bcdf8d.png)
