### PR TITLE
Making shell.lookedUp cache thread-safe

### DIFF
--- a/cmd/shell/lookupCache.go
+++ b/cmd/shell/lookupCache.go
@@ -1,0 +1,35 @@
+package shell
+
+import "sync"
+
+type lookupCache struct {
+	mtx   *sync.RWMutex
+	cache map[string]error
+}
+
+func newLookupCache() *lookupCache {
+	var mtx sync.RWMutex
+	return &lookupCache{&mtx, nil}
+}
+
+func (l *lookupCache) fetch(key string) (exists bool, err error) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	if l.cache != nil {
+		err, exists = l.cache[key]
+	}
+
+	return
+}
+
+func (l *lookupCache) set(key string, err error) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	if l.cache == nil {
+		l.cache = make(map[string]error)
+	}
+
+	l.cache[key] = err
+}

--- a/cmd/shell/lookupCache.go
+++ b/cmd/shell/lookupCache.go
@@ -13,8 +13,8 @@ func newLookupCache() *lookupCache {
 }
 
 func (l *lookupCache) fetch(key string) (exists bool, err error) {
-	l.mtx.Lock()
-	defer l.mtx.Unlock()
+	l.mtx.RLock()
+	defer l.mtx.RUnlock()
 
 	if l.cache != nil {
 		err, exists = l.cache[key]

--- a/cmd/shell/lookupCache_test.go
+++ b/cmd/shell/lookupCache_test.go
@@ -1,0 +1,29 @@
+package shell
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestLookupCache(t *testing.T) {
+	cache := newLookupCache()
+
+	if cache.mtx == nil {
+		t.Error("missing mtx on lookupCache")
+	}
+
+	if cache.cache != nil {
+		t.Errorf("unexpected default non-nil value for cache: %v", cache.cache)
+	}
+
+	if exists, err := cache.fetch("unknown"); err != nil || exists {
+		t.Errorf("bad return for fetching unknown key from cache")
+	}
+
+	var err = errors.New("error")
+	cache.set("key", err)
+
+	if exists, cached := cache.fetch("key"); !exists || !errors.Is(cached, err) {
+		t.Errorf("failed to fetch error from cache - exists: %v got: %v expected: %v", exists, cached, err)
+	}
+}

--- a/cmd/shell/shell_test.go
+++ b/cmd/shell/shell_test.go
@@ -111,6 +111,7 @@ func TestExecDockerComposeDefaultShell(t *testing.T) {
 		outStream: ioutil.Discard,
 		errStream: os.Stderr,
 		env:       environment.NewFakeEnvStorage(),
+		lookedUp:  newLookupCache(),
 	}
 
 	s.env.Set("KOOL_NAME", "kool_test")
@@ -190,6 +191,7 @@ func TestInteractiveDockerComposeDefaultShell(t *testing.T) {
 		outStream: ioutil.Discard,
 		errStream: os.Stderr,
 		env:       environment.NewFakeEnvStorage(),
+		lookedUp:  newLookupCache(),
 	}
 
 	s.env.Set("KOOL_NAME", "kool_test")


### PR DESCRIPTION
Signed-off-by: fabriciojs <fajosesouza@gmail.com>

<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | #256 |
| -----: | :-----: |
| :beetle: Bug Fix | Yes |
| :warning: Break Change | No |

**Description**

We had a race condition that could generate a panic when writing simultaneously to a map (happened in some instances for `kool status`). The `shell.Exec` uses a cache for `os.LookPath` and such caching was unsafe for concurrency.

Introducing a new wrapper for the cache with `sync.RWMutext` for guaranteeing thread-safeness.