### PR TITLE
add scan job to pull_requests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
     - '*'
 
 jobs:
-  build:
+  docker-build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,25 @@
+name: scan
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  grype:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@master
+
+    - name: Build image
+      run: docker build --pull -t kooldev/kool:4scan .
+
+    - name: Scan image
+      uses: anchore/scan-action@v2
+      with:
+        image: "kooldev/kool:4scan"
+        fail-build: true
+        severity-cutoff: critical


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | #258 |
| -----: | :-----: |
| :warning: Break Change | No |

**Description**

After #258 I realized we would only check for vulnerabilities in the image upon tagging a new version (when the `docker` workflow is triggered). So I added a new `scan` workflow to run upon pull_requests, so we check before merging.

---

**Notes**

We should see the green check for `scan` workflow in this very PR.

![image](https://user-images.githubusercontent.com/1116377/106783916-8a4e9f00-662a-11eb-9675-c79741114e39.png)
