### PR TITLE
fix recursive call with input file redirection + tests

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package cmd
 
 import (

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"kool-dev/kool/cmd/builder"
 	"kool-dev/kool/cmd/parser"
@@ -352,7 +353,7 @@ func TestRunRecursiveCalls(t *testing.T) {
 		root := NewRootCmd(k.env)
 		root.AddCommand(NewRunCommand(k))
 
-		shell.RecursiveCall = func(args []string) error {
+		shell.RecursiveCall = func(args []string, in io.Reader, out, err io.Writer) error {
 			fmt.Printf("called RecursiveCall args: %v\n", args)
 			root.SetArgs(args)
 			return root.Execute()
@@ -386,5 +387,64 @@ func TestRunRecursiveCalls(t *testing.T) {
 
 	if err := root.Execute(); err != nil {
 		t.Errorf("unexpected error executing run recursive; error: %v", err)
+	}
+}
+
+const inputContent string = "input file"
+
+func TestRunRecursiveCallsWithInputRedirecting(t *testing.T) {
+	makeKoolRoot := func() *cobra.Command {
+		k := NewKoolRun()
+		k.env = environment.NewFakeEnvStorage()
+		k.env.Set("HOME", "")
+		tmp := t.TempDir()
+		inputFilePath := fmt.Sprintf("%s/input_file", tmp)
+		k.env.Set("PWD", tmp)
+
+		kooYml := []byte(fmt.Sprintf(`scripts:
+  input: kool receive-file < %s
+`, inputFilePath))
+
+		if err := ioutil.WriteFile(fmt.Sprintf("%s/kool.yml", tmp), kooYml, os.ModePerm); err != nil {
+			t.Fatalf("failed creating temp kool.yml for testing: %v", err)
+		}
+		if err := ioutil.WriteFile(inputFilePath, []byte(inputContent), os.ModePerm); err != nil {
+			t.Fatalf("failed creating temp %v for testing: %v", inputFilePath, err)
+		}
+
+		root := NewRootCmd(k.env)
+		root.AddCommand(NewRunCommand(k))
+		root.AddCommand(&cobra.Command{
+			Use: "receive-file",
+			Run: func(cmd *cobra.Command, args []string) {
+				if shell.NewTerminalChecker().IsTerminal(cmd.InOrStdin()) {
+					t.Errorf("unexpected input - TTY - %T", cmd.InOrStdin())
+				}
+				if file, isFile := cmd.InOrStdin().(*os.File); !isFile {
+					t.Errorf("unexpected input - should be a file; but is %T", cmd.InOrStdin())
+				} else if input, err := ioutil.ReadAll(file); err != nil {
+					t.Errorf("failed reading input file: %v", err)
+				} else if string(input) != inputContent {
+					t.Errorf("unexpcted content on input file: %v", input)
+				}
+			},
+		})
+
+		setRecursiveCall(root)
+
+		return root
+	}
+
+	defer func() {
+		// clear up shell.RecursiveCall
+		shell.RecursiveCall = nil
+	}()
+
+	root := makeKoolRoot()
+
+	root.SetArgs([]string{"run", "input"})
+
+	if err := root.Execute(); err != nil {
+		t.Errorf("unexpected error executing run show-version; error: %v", err)
 	}
 }

--- a/cmd/shell/fake_terminal.go
+++ b/cmd/shell/fake_terminal.go
@@ -7,7 +7,7 @@ type FakeTerminalChecker struct {
 }
 
 // IsTerminal implements fake IsTerminal
-func (f *FakeTerminalChecker) IsTerminal(in interface{}, out interface{}) (isTerminal bool) {
+func (f *FakeTerminalChecker) IsTerminal(fds ...interface{}) (isTerminal bool) {
 	f.CalledIsTerminal = true
 	isTerminal = f.MockIsTerminal
 	return

--- a/cmd/shell/shell_test.go
+++ b/cmd/shell/shell_test.go
@@ -389,7 +389,7 @@ func TestRecursiveInteractiveCommand(t *testing.T) {
 	}()
 
 	// set published RecursiveCall handler
-	RecursiveCall = func(args []string) error {
+	RecursiveCall = func(args []string, in io.Reader, out, err io.Writer) error {
 		calledRecursive = true
 		calledRecursiveArgs = args
 		return nil

--- a/cmd/shell/terminal.go
+++ b/cmd/shell/terminal.go
@@ -4,19 +4,21 @@ import "github.com/moby/term"
 
 // TerminalChecker holds logic to check if environment is a terminal
 type TerminalChecker interface {
-	IsTerminal(interface{}, interface{}) bool
+	IsTerminal(...interface{}) bool
 }
 
-// DefaultTerminalChecker holds data to check if environment is a terminal
+// DefaultTerminalChecker holds logic to check if file descriptors are a TTY
 type DefaultTerminalChecker struct{}
 
 // IsTerminal checks if input is a terminal
-func (t *DefaultTerminalChecker) IsTerminal(in interface{}, out interface{}) (isTerminal bool) {
-	_, inIsTerminal := term.GetFdInfo(in)
-	_, outIsTerminal := term.GetFdInfo(out)
+func (t *DefaultTerminalChecker) IsTerminal(fds ...interface{}) bool {
+	for i := range fds {
+		if _, isTerminal := term.GetFdInfo(fds[i]); !isTerminal {
+			return false
+		}
+	}
 
-	isTerminal = inIsTerminal && outIsTerminal
-	return
+	return true
 }
 
 // NewTerminalChecker creates a new terminal checker


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | #262  |
| -----: | :-----: |
| :beetle: Bug Fix | Yes |
| :warning: Break Change | No |

**Description**

The recursive calls to `kool` itself made internally were ignoring the real indented input/output. Now the recursive call happens after input/output redirection parsing.

---

**Notes**

I was able to get a regression test for this situation, worth paying closer attention to `TestRunRecursiveCallsWithInputRedirecting`
