### PR TITLE
fix status when no containers are running

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -165,14 +165,13 @@ func (s *KoolStatus) getServiceInfo(service string, chStatus chan *statusService
 
 	defer wg.Done()
 
-	ss := &statusService{service: service}
+	ss := &statusService{service: service, running: "Not running"}
 
 	if serviceID, err = s.Exec(s.getServiceIDCmd, service); err != nil {
 		ss.err = err
 	} else if serviceID != "" {
 		status, port = s.getStatusPort(serviceID)
 
-		ss.running = "Not running"
 		if strings.HasPrefix(status, "Up") {
 			ss.running = "Running"
 		}


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | https://github.com/kool-dev/kool/issues/267 |
| -----: | :-----: |
| :beetle: Bug Fix | Yes |
| :warning: Break Change | No |

**Description**

Fixed default status so `kool status` will always by default return `Not Running`
