### PR TITLE
fix broken (*compose.DockerCompose).Copy method

### DIFF
--- a/cmd/compose/docker-compose.go
+++ b/cmd/compose/docker-compose.go
@@ -115,3 +115,8 @@ func (c *DockerCompose) Cmd() string {
 func (c *DockerCompose) String() string {
 	return strings.Trim(fmt.Sprintf("%s %s", c.Cmd(), strings.Join(c.Args(), " ")), " ")
 }
+
+// Copy clones the pointer to avoid unintended modifications
+func (c *DockerCompose) Copy() builder.Command {
+	return NewDockerCompose(c.Command.Cmd(), c.Command.Args()...)
+}

--- a/cmd/compose/docker-compose_test.go
+++ b/cmd/compose/docker-compose_test.go
@@ -99,4 +99,8 @@ func TestDockerComposeArgsParsing(t *testing.T) {
 	if dc.Cmd() != "docker" {
 		t.Error("unexpected Cmd() return")
 	}
+
+	if cp, ok := dc.Copy().(*DockerCompose); !ok || cp == nil || cp.Command.Cmd() != dc.Command.Cmd() || len(cp.Command.Args()) != len(dc.Command.Args()) {
+		t.Error("bad copy")
+	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | - |
| -----: | :-----: |
| :beetle: Bug Fix | Yes |
| :warning: Break Change | Yes/No |

**Description**

Recently introduced `builder.Command.Copy()` was making compose.DockerCompose to be lost within shell.Interactive, which would cause for not found command errors.

---

**Notes**

The test here tackles only the Copy itself. I plan on writing some end-to-end test so we can catch stuff like this before in our workflow.
