### PR TITLE
add stale bot to housekeeping issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 15
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - R&D
+  - security
+  - enhancement
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | https://github.com/kool-dev/kool/issues/253 |
| -----: | :-----: |
| :warning: Break Change | No |

**Description**

Adding https://probot.github.io/apps/stale/ to mark/close old issues without recent activities.

---

**Notes**

Overall we should benefit from a cleaner/simpler issues dashboard for bugs, questions, and external proposals only whereas we shall manage the backlog out of the default GH issues.