### PR TITLE
Kool stop - accepting service arguments

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -65,7 +65,7 @@ func (s *KoolStop) Execute(args []string) (err error) {
 		if s.Flags.Purge {
 			s.rm.AppendArgs("-v") // removes volumes
 
-			s.Warning("Attention: when stopping specific services, only annonymous volumes will be removed.")
+			s.Warning("Attention: when stopping specific services, only anonymous volumes will be removed.")
 		}
 
 		s.rm.AppendArgs(args...)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -61,7 +61,7 @@ func (s *KoolStop) Execute(args []string) (err error) {
 		stopCommand = s.down
 	} else {
 		// we should only stop some services!
-		s.rm.AppendArgs("-s") // stops containers
+		s.rm.AppendArgs("-s", "-f") // stops containers; no interactive
 		if s.Flags.Purge {
 			s.rm.AppendArgs("-v") // removes volumes
 		}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -81,7 +81,7 @@ func (s *KoolStop) Execute(args []string) (err error) {
 func NewStopCommand(stop *KoolStop) (stopCmd *cobra.Command) {
 	stopCmd = &cobra.Command{
 		Use:   "stop [SERVICE]",
-		Short: "Stop and destroy running containers started with 'kool start' command. If not SERVICE is specified as argument all containers will be stopped.",
+		Short: "Stop and destroy running containers started with 'kool start' command. If no SERVICE is specified as an argument all containers will be stopped.",
 		Run:   DefaultCommandRunFunction(stop),
 	}
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -64,6 +64,8 @@ func (s *KoolStop) Execute(args []string) (err error) {
 		s.rm.AppendArgs("-s", "-f") // stops containers; no interactive
 		if s.Flags.Purge {
 			s.rm.AppendArgs("-v") // removes volumes
+
+			s.Warning("Attention: when stopping specific services, only annonymous volumes will be removed.")
 		}
 
 		s.rm.AppendArgs(args...)

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -18,8 +18,9 @@ type KoolStop struct {
 	DefaultKoolService
 	Flags *KoolStopFlags
 
-	check  checker.Checker
-	doStop builder.Command
+	check checker.Checker
+	down  builder.Command
+	rm    builder.Command
 }
 
 func init() {
@@ -39,29 +40,46 @@ func NewKoolStop() *KoolStop {
 		&KoolStopFlags{false},
 		checker.NewChecker(defaultKoolService.shell),
 		compose.NewDockerCompose("down"),
+		compose.NewDockerCompose("rm"),
 	}
 }
 
 // Execute runs the stop logic with incoming arguments.
 func (s *KoolStop) Execute(args []string) (err error) {
+	var stopCommand builder.Command
+
 	if err = s.check.Check(); err != nil {
 		return
 	}
 
-	if s.Flags.Purge {
-		s.doStop.AppendArgs("--volumes", "--remove-orphans")
+	if len(args) == 0 {
+		// no specific services passed in, so we gonna 'docker-compose down'
+		if s.Flags.Purge {
+			s.down.AppendArgs("--volumes", "--remove-orphans")
+		}
+
+		stopCommand = s.down
+	} else {
+		// we should only stop some services!
+		s.rm.AppendArgs("-s") // stops containers
+		if s.Flags.Purge {
+			s.rm.AppendArgs("-v") // removes volumes
+		}
+
+		s.rm.AppendArgs(args...)
+
+		stopCommand = s.rm
 	}
 
-	err = s.Interactive(s.doStop)
+	err = s.Interactive(stopCommand)
 	return
 }
 
 // NewStopCommand initializes new kool stop command
 func NewStopCommand(stop *KoolStop) (stopCmd *cobra.Command) {
 	stopCmd = &cobra.Command{
-		Use:   "stop",
-		Short: "Stop all running containers started with 'kool start' command",
-		Args:  cobra.NoArgs,
+		Use:   "stop [SERVICE]",
+		Short: "Stop and destroy running containers started with 'kool start' command. If not SERVICE is specified as argument all containers will be stopped.",
 		Run:   DefaultCommandRunFunction(stop),
 	}
 

--- a/cmd/stop_test.go
+++ b/cmd/stop_test.go
@@ -82,13 +82,13 @@ func TestNewStopCommandWithArgument(t *testing.T) {
 		t.Error("should have called AppendArgs on KoolStop.rm Command")
 	}
 	appended := f.rm.(*builder.FakeCommand).ArgsAppend
-	if len(appended) != 3 {
+	if len(appended) != 4 {
 		t.Errorf("unexpected number of appended args; got %d expected 3", len(appended))
 	}
-	if appended[0] != "-s" {
-		t.Error("expected to have set -s flag")
+	if appended[0] != "-s" || appended[1] != "-f" {
+		t.Error("expected to have set -s -f flags")
 	}
-	if appended[1] != "a" && appended[2] != "b" {
+	if appended[2] != "a" && appended[3] != "b" {
 		t.Error("unexpected arguments on services list")
 	}
 }
@@ -126,7 +126,7 @@ func TestNewStopPurgeCommandWithServices(t *testing.T) {
 	}
 
 	appended := f.rm.(*builder.FakeCommand).ArgsAppend
-	if len(appended) != 4 || appended[0] != "-s" || appended[1] != "-v" {
+	if len(appended) != 5 || appended[0] != "-s" || appended[1] != "-f" || appended[2] != "-v" {
 		t.Errorf("bad arguments to KoolStop.rm Command when passing --purge flag")
 	}
 }

--- a/docs/4-Commands/0-kool.md
+++ b/docs/4-Commands/0-kool.md
@@ -28,5 +28,5 @@ Complete documentation is available at https://kool.dev/docs
 * [kool self-update](kool-self-update.md)	 - Update kool to latest version
 * [kool start](kool-start.md)	 - Start the specified Kool environment containers. If no service is specified, start all.
 * [kool status](kool-status.md)	 - Shows the status for containers
-* [kool stop](kool-stop.md)	 - Stop all running containers started with 'kool start' command
+* [kool stop](kool-stop.md)	 - Stop and destroy running containers started with 'kool start' command. If not SERVICE is specified as argument all containers will be stopped.
 

--- a/docs/4-Commands/kool-stop.md
+++ b/docs/4-Commands/kool-stop.md
@@ -1,9 +1,9 @@
 ## kool stop
 
-Stop all running containers started with 'kool start' command
+Stop and destroy running containers started with 'kool start' command. If not SERVICE is specified as argument all containers will be stopped.
 
 ```
-kool stop [flags]
+kool stop [SERVICE] [flags]
 ```
 
 ### Options


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | #87  |
| -----: | :-----: |
| :trophy: Feature | Yes |
| :warning: Break Change | No |

**Description**

Added optional arguments to `kool stop` for stopping specific containers.

---

**Notes**

The behaviour is overall preserved where we destroy the container and, if `--purge`, also remove the named volumes.
