### PR TITLE
added kool share command - make local environment available on kool.live

### DIFF
--- a/cmd/share.go
+++ b/cmd/share.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"fmt"
+	"kool-dev/kool/cmd/builder"
+	"kool-dev/kool/environment"
+	"regexp"
+
+	"github.com/spf13/cobra"
+)
+
+// KoolShareFlags holds the flags for the kool stop command
+type KoolShareFlags struct {
+	Service   string
+	Subdomain string
+}
+
+// KoolShare holds handlers and functions to implement the stop command logic
+type KoolShare struct {
+	DefaultKoolService
+	Flags *KoolShareFlags
+
+	env environment.EnvStorage
+
+	status *KoolStatus
+	share  builder.Command
+}
+
+func init() {
+	var (
+		share    = NewKoolShare()
+		shareCmd = NewShareCommand(share)
+	)
+
+	rootCmd.AddCommand(shareCmd)
+}
+
+// NewKoolShare creates a new handler for sharing local environment with default dependencies
+func NewKoolShare() *KoolShare {
+	defaultKoolService := newDefaultKoolService()
+	return &KoolShare{
+		*defaultKoolService,
+		&KoolShareFlags{"app", ""},
+		environment.NewEnvStorage(),
+		NewKoolStatus(),
+		builder.NewCommand("docker", "run", "--rm", "--init"),
+	}
+}
+
+// validSubdomain runs the stop logic with incoming arguments.
+func (s *KoolShare) validSubdomain(subdomain string) bool {
+	return regexp.MustCompile("^[a-z]+[a-z0-9]+$").MatchString(subdomain)
+}
+
+// Execute runs the stop logic with incoming arguments.
+func (s *KoolShare) Execute(args []string) (err error) {
+	var isRunning bool
+
+	if isRunning, _, _, err = s.status.getServiceInfo(s.Flags.Service); err != nil {
+		return
+	}
+
+	if !isRunning {
+		err = fmt.Errorf("service %s is not running, please check kool status and use --service flag to set which service to share", s.Flags.Service)
+		return
+	}
+
+	s.share.AppendArgs("--network", s.env.Get("KOOL_GLOBAL_NETWORK"))
+	s.share.AppendArgs("beyondcodegmbh/expose-server:1.4.1", "share")
+	s.share.AppendArgs(s.Flags.Service)
+	s.share.AppendArgs("--server-host", "kool.live")
+
+	if s.Flags.Subdomain != "" {
+		if !s.validSubdomain(s.Flags.Subdomain) {
+			err = fmt.Errorf("invalid subdomain '%s'", s.Flags.Subdomain)
+			return
+		}
+
+		s.share.AppendArgs("--subdomain", s.Flags.Subdomain)
+	}
+
+	err = s.Interactive(s.share)
+	return
+}
+
+// NewShareCommand initializes new kool stop command
+func NewShareCommand(share *KoolShare) (shareCmd *cobra.Command) {
+	shareCmd = &cobra.Command{
+		Use:   "share",
+		Short: "Live share your local environment through an HTTP tunnel with anyone, anywhere.",
+		Args:  cobra.NoArgs,
+		Run:   DefaultCommandRunFunction(share),
+	}
+
+	shareCmd.Flags().StringVarP(&share.Flags.Service, "service", "", "app", "The name of the local service container we want to share.")
+	shareCmd.Flags().StringVarP(&share.Flags.Subdomain, "subdomain", "", "", "The subdomain desired for subdomain.kool.dev.")
+	return
+}

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -5,6 +5,7 @@ import (
 	"kool-dev/kool/cmd/builder"
 	"kool-dev/kool/environment"
 	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -49,7 +50,7 @@ func NewKoolShare() *KoolShare {
 
 // validSubdomain runs the stop logic with incoming arguments.
 func (s *KoolShare) validSubdomain(subdomain string) bool {
-	return regexp.MustCompile("^[a-z]+[a-z0-9]+$").MatchString(subdomain)
+	return regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$").MatchString(subdomain)
 }
 
 // Execute runs the stop logic with incoming arguments.
@@ -71,6 +72,7 @@ func (s *KoolShare) Execute(args []string) (err error) {
 	s.share.AppendArgs("--server-host", "kool.live")
 
 	if s.Flags.Subdomain != "" {
+		s.Flags.Subdomain = strings.ToLower(s.Flags.Subdomain)
 		if !s.validSubdomain(s.Flags.Subdomain) {
 			err = fmt.Errorf("invalid subdomain '%s'", s.Flags.Subdomain)
 			return

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// KoolShareFlags holds the flags for the kool stop command
+// KoolShareFlags holds the flags for the kool share command
 type KoolShareFlags struct {
 	Service   string
 	Subdomain string
@@ -25,7 +25,7 @@ func (f *KoolShareFlags) parseServiceURI() string {
 	return f.Service
 }
 
-// KoolShare holds handlers and functions to implement the stop command logic
+// KoolShare holds handlers and functions to implement the share command logic
 type KoolShare struct {
 	DefaultKoolService
 	Flags *KoolShareFlags
@@ -57,12 +57,11 @@ func NewKoolShare() *KoolShare {
 	}
 }
 
-// validSubdomain runs the stop logic with incoming arguments.
 func (s *KoolShare) validSubdomain(subdomain string) bool {
 	return regexp.MustCompile("^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$").MatchString(subdomain)
 }
 
-// Execute runs the stop logic with incoming arguments.
+// Execute runs the share logic.
 func (s *KoolShare) Execute(args []string) (err error) {
 	var isRunning bool
 
@@ -94,7 +93,7 @@ func (s *KoolShare) Execute(args []string) (err error) {
 	return
 }
 
-// NewShareCommand initializes new kool stop command
+// NewShareCommand initializes new kool share command
 func NewShareCommand(share *KoolShare) (shareCmd *cobra.Command) {
 	shareCmd = &cobra.Command{
 		Use:   "share",

--- a/cmd/share_test.go
+++ b/cmd/share_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"errors"
+	"kool-dev/kool/cmd/builder"
+	"kool-dev/kool/cmd/shell"
+	"kool-dev/kool/environment"
+	"strings"
+	"testing"
+)
+
+func TestShareDefaults(t *testing.T) {
+	share := NewKoolShare()
+
+	if share.Flags.Service != "app" {
+		t.Errorf("bad default service; expected app but got %s", share.Flags.Service)
+	}
+
+	if _, ok := share.env.(*environment.DefaultEnvStorage); !ok {
+		t.Error("bad default environment.EnvStorage implementation")
+	}
+
+	if len(share.share.Args()) != 3 || share.share.Cmd() != "docker" {
+		t.Error("bad default builder.Command for sharing")
+	}
+}
+
+func newFakeShareService() *KoolShare {
+	return &KoolShare{
+		*newFakeKoolService(),
+		&KoolShareFlags{"default-service", "default-subdomain"},
+		environment.NewFakeEnvStorage(),
+		newFakeKoolStatus(),
+		&builder.FakeCommand{},
+	}
+}
+
+func TestShareCommand(t *testing.T) {
+	share := newFakeShareService()
+	share.status.getServiceIDCmd.(*builder.FakeCommand).MockExecOut = "100"
+	share.status.getServiceStatusPortCmd.(*builder.FakeCommand).MockExecOut = "Up About an hour|0.0.0.0:80->80/tcp, 9000/tcp"
+
+	cmd := NewShareCommand(share)
+
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("unexpected error on sharing: %v", err)
+	}
+}
+
+func TestShareCommandBadDomain(t *testing.T) {
+	share := newFakeShareService()
+	share.status.getServiceIDCmd.(*builder.FakeCommand).MockExecOut = "100"
+	share.status.getServiceStatusPortCmd.(*builder.FakeCommand).MockExecOut = "Up About an hour|0.0.0.0:80->80/tcp, 9000/tcp"
+
+	cmd := NewShareCommand(share)
+	cmd.SetArgs([]string{"--subdomain", "000"})
+	if err := cmd.Execute(); err != nil {
+		t.Error("unexpected error on running command")
+	} else if err = share.shell.(*shell.FakeShell).Err; err == nil {
+		t.Error("expected error but got none")
+	} else if !strings.Contains(err.Error(), "invalid subdomain") {
+		t.Errorf("invalid error; expected 'invalid subdomain' but got %s", err.Error())
+	}
+}
+
+func TestShareCommandServiceNotRunning(t *testing.T) {
+	share := newFakeShareService()
+
+	cmd := NewShareCommand(share)
+	if err := cmd.Execute(); err != nil {
+		t.Error("unexpected error on running command")
+	} else if err = share.shell.(*shell.FakeShell).Err; err == nil {
+		t.Error("expected error but got none")
+	} else if !strings.Contains(err.Error(), "is not running") {
+		t.Errorf("invalid error; expected 'is not running' but got %s", err.Error())
+	}
+}
+
+func TestShareCommandServiceDoesNotExist(t *testing.T) {
+	share := newFakeShareService()
+	share.status.getServiceIDCmd.(*builder.FakeCommand).MockExecError = errors.New("fake error")
+
+	cmd := NewShareCommand(share)
+	if err := cmd.Execute(); err != nil {
+		t.Error("unexpected error on running command")
+	} else if err = share.shell.(*shell.FakeShell).Err; err == nil {
+		t.Error("expected error but got none")
+	} else if !strings.Contains(err.Error(), "fake error") {
+		t.Errorf("invalid error; expected 'fake error' but got %s", err.Error())
+	}
+}
+
+func TestShareCommandSetFlags(t *testing.T) {
+	share := newFakeShareService()
+	share.status.getServiceIDCmd.(*builder.FakeCommand).MockExecOut = "100"
+	share.status.getServiceStatusPortCmd.(*builder.FakeCommand).MockExecOut = "Up About an hour|0.0.0.0:80->80/tcp, 9000/tcp"
+
+	cmd := NewShareCommand(share)
+	cmd.SetArgs([]string{"--subdomain", "sub", "--service", "foo"})
+	if err := cmd.Execute(); err != nil {
+		t.Error("unexpected error on running command")
+	} else if err = share.shell.(*shell.FakeShell).Err; err != nil {
+		t.Error("unexpected error")
+	}
+	args := share.share.(*builder.FakeCommand).ArgsAppend
+	if args[4] != "foo" {
+		t.Error("failed setting service")
+	}
+	if args[8] != "sub" {
+		t.Error("failed setting subdomain")
+	}
+}

--- a/cmd/share_test.go
+++ b/cmd/share_test.go
@@ -28,10 +28,24 @@ func TestShareDefaults(t *testing.T) {
 func newFakeShareService() *KoolShare {
 	return &KoolShare{
 		*newFakeKoolService(),
-		&KoolShareFlags{"default-service", "default-subdomain"},
+		&KoolShareFlags{"default-service", "default-subdomain", 0},
 		environment.NewFakeEnvStorage(),
 		newFakeKoolStatus(),
 		&builder.FakeCommand{},
+	}
+}
+
+func TestFlagParseServiceURI(t *testing.T) {
+	f := &KoolShareFlags{"service", "", 10}
+
+	if f.parseServiceURI() != "service:10" {
+		t.Errorf("bad service URI generated from flags; expected service:10 but got: %s", f.parseServiceURI())
+	}
+
+	f.Port = 0
+
+	if f.parseServiceURI() != "service" {
+		t.Errorf("bad service URI generated from flags; expected service but got: %s", f.parseServiceURI())
 	}
 }
 
@@ -53,7 +67,7 @@ func TestShareCommandBadDomain(t *testing.T) {
 	share.status.getServiceStatusPortCmd.(*builder.FakeCommand).MockExecOut = "Up About an hour|0.0.0.0:80->80/tcp, 9000/tcp"
 
 	cmd := NewShareCommand(share)
-	cmd.SetArgs([]string{"--subdomain", "000"})
+	cmd.SetArgs([]string{"--subdomain", "-sub"})
 	if err := cmd.Execute(); err != nil {
 		t.Error("unexpected error on running command")
 	} else if err = share.shell.(*shell.FakeShell).Err; err == nil {

--- a/docs/4-Commands/0-kool.md
+++ b/docs/4-Commands/0-kool.md
@@ -26,6 +26,7 @@ Complete documentation is available at https://kool.dev/docs
 * [kool restart](kool-restart.md)	 - Restart containers - the same as stop followed by start.
 * [kool run](kool-run.md)	 - Runs a custom command defined at kool.yaml in the working directory or in the kool folder of the user's home directory
 * [kool self-update](kool-self-update.md)	 - Update kool to latest version
+* [kool share](kool-share.md)	 - Live share your local environment through an HTTP tunnel with anyone, anywhere.
 * [kool start](kool-start.md)	 - Start the specified Kool environment containers. If no service is specified, start all.
 * [kool status](kool-status.md)	 - Shows the status for containers
 * [kool stop](kool-stop.md)	 - Stop all running containers started with 'kool start' command

--- a/docs/4-Commands/kool-share.md
+++ b/docs/4-Commands/kool-share.md
@@ -1,0 +1,26 @@
+## kool share
+
+Live share your local environment through an HTTP tunnel with anyone, anywhere.
+
+```
+kool share [flags]
+```
+
+### Options
+
+```
+  -h, --help               help for share
+      --service string     The name of the local service container we want to share. (default "app")
+      --subdomain string   The subdomain desired for subdomain.kool.dev.
+```
+
+### Options inherited from parent commands
+
+```
+      --verbose   increases output verbosity
+```
+
+### SEE ALSO
+
+* [kool](kool.md)	 - kool - Kool stuff
+

--- a/docs/4-Commands/kool-share.md
+++ b/docs/4-Commands/kool-share.md
@@ -10,6 +10,7 @@ kool share [flags]
 
 ```
   -h, --help               help for share
+      --port uint          The port from the target service that should be shared. If not provided it will default to port 80.
       --service string     The name of the local service container we want to share. (default "app")
       --subdomain string   The subdomain desired for subdomain.kool.dev.
 ```


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | #225  |
| -----: | :-----: |
| :trophy: Feature | Yes |
| :pencil: Refactor | Yes |
| :open_book: Documentation | Yes |
| :warning: Break Change | No |

**Description**

Adding the new `kool share` command which allows for anyone using `kool` for local development to quickly share their local work through an HTTP tunnel on `kool.live` to anyone, anywhere. Think of it as `Ngrok` or `vagrant share` for `kool`!

---

**Notes**

- By default, the `app` service will be shared, but it can be changed using the `--service` flag.
- `kool.live` is a BeyondCode Expose server managed by us.
