### PR TITLE
refactor: adding subcommands on root level

### DIFF
--- a/cmd/builder/command.go
+++ b/cmd/builder/command.go
@@ -14,8 +14,8 @@ var splitFn splitFnType = shlex.Split
 
 // DefaultCommand holds data and logic for an executable command.
 type DefaultCommand struct {
-	command            string
-	args, originalArgs []string
+	command string
+	args    []string
 }
 
 // Command holds available methods for building commands.
@@ -24,7 +24,6 @@ type Command interface {
 	AppendArgs(...string)
 	String() string
 	Args() []string
-	Reset()
 	Cmd() string
 	Copy() Command
 }
@@ -36,7 +35,7 @@ type Parser interface {
 
 // NewCommand Create a new command.
 func NewCommand(command string, args ...string) *DefaultCommand {
-	return &DefaultCommand{command, args, args}
+	return &DefaultCommand{command, args}
 }
 
 // ParseCommand transforms a command line string into separated
@@ -49,18 +48,13 @@ func ParseCommand(line string) (command *DefaultCommand, err error) {
 		return
 	}
 
-	command = &DefaultCommand{parsed[0], parsed[1:], parsed[1:]}
+	command = &DefaultCommand{parsed[0], parsed[1:]}
 	return
 }
 
 // AppendArgs allows to appending arguments to the command builder.
 func (c *DefaultCommand) AppendArgs(args ...string) {
 	c.args = append(c.args, args...)
-}
-
-// Reset returns args to original state
-func (c *DefaultCommand) Reset() {
-	c.args = c.originalArgs
 }
 
 // String returns a string representation of the command.

--- a/cmd/builder/command_test.go
+++ b/cmd/builder/command_test.go
@@ -71,17 +71,6 @@ func TestAppendArgs(t *testing.T) {
 	}
 }
 
-func TestResetArgs(t *testing.T) {
-	cmd := NewCommand("echo", "x1")
-
-	cmd.AppendArgs("x2")
-	cmd.Reset()
-
-	if len(cmd.args) != 1 || cmd.args[0] != "x1" {
-		t.Errorf("Reset failed to return args")
-	}
-}
-
 func TestString(t *testing.T) {
 	cmd := NewCommand("echo", "x1", "x2")
 

--- a/cmd/builder/fake_command.go
+++ b/cmd/builder/fake_command.go
@@ -7,7 +7,6 @@ type FakeCommand struct {
 	CalledString       bool
 	CalledCmd          bool
 	CalledArgs         bool
-	CalledReset        bool
 	CalledParseCommand bool
 
 	MockCmd              string
@@ -34,11 +33,6 @@ func (f *FakeCommand) String() string {
 func (f *FakeCommand) Args() []string {
 	f.CalledArgs = true
 	return f.ArgsAppend
-}
-
-// Reset resets arguments
-func (f *FakeCommand) Reset() {
-	f.CalledReset = true
 }
 
 // Cmd returns the command executable

--- a/cmd/builder/fake_command_test.go
+++ b/cmd/builder/fake_command_test.go
@@ -37,10 +37,6 @@ func TestFakeCommand(t *testing.T) {
 	if !f.CalledParseCommand || err == nil || err.Error() != "parse error" {
 		t.Errorf("failed to use mocked Parse function on FakeCommand")
 	}
-
-	if f.Reset(); !f.CalledReset {
-		t.Error("failed asserting that called Reset")
-	}
 }
 
 func TestFakeCopy(t *testing.T) {

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -8,20 +8,20 @@ type KoolCompletion struct {
 	rootCmd *cobra.Command
 }
 
-func init() {
+func AddKoolCompletion(root *cobra.Command) {
 	var (
-		completion    = NewKoolCompletion()
+		completion    = NewKoolCompletion(root)
 		completionCmd = NewCompletionCommand(completion)
 	)
 
-	rootCmd.AddCommand(completionCmd)
+	root.AddCommand(completionCmd)
 }
 
 // NewKoolCompletion creates a new handler for completion logic
-func NewKoolCompletion() *KoolCompletion {
+func NewKoolCompletion(root *cobra.Command) *KoolCompletion {
 	return &KoolCompletion{
 		*newDefaultKoolService(),
-		rootCmd,
+		root,
 	}
 }
 

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -69,7 +69,7 @@ func expectedCompletionOutput(shellType string) (expected string, err error) {
 }
 
 func TestNewKoolCompletion(t *testing.T) {
-	k := NewKoolCompletion()
+	k := NewKoolCompletion(rootCmd)
 
 	if _, ok := k.DefaultKoolService.shell.(*shell.DefaultShell); !ok {
 		t.Error("unexpected shell.Shell on default KoolCompletion instance")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -19,13 +19,13 @@ type KoolCreate struct {
 	KoolPreset
 }
 
-func init() {
+func AddKoolCreate(root *cobra.Command) {
 	var (
 		create    = NewKoolCreate()
 		createCmd = NewCreateCommand(create)
 	)
 
-	rootCmd.AddCommand(createCmd)
+	root.AddCommand(createCmd)
 }
 
 // NewKoolCreate creates a new handler for create logic
@@ -56,7 +56,7 @@ func (c *KoolCreate) Execute(args []string) (err error) {
 	c.parser.LoadConfigs(presets.GetConfigs())
 
 	if !c.parser.Exists(preset) {
-		err = fmt.Errorf("Unknown preset %s", preset)
+		err = fmt.Errorf("unknown preset %s", preset)
 		return
 	}
 
@@ -66,7 +66,7 @@ func (c *KoolCreate) Execute(args []string) (err error) {
 	}
 
 	if createCmds, ok = presetConfig.Commands["create"]; !ok || len(createCmds) <= 0 {
-		err = fmt.Errorf("No create commands were found for preset %s", preset)
+		err = fmt.Errorf("no create commands were found for preset %s", preset)
 		return
 	}
 

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -51,9 +51,9 @@ func TestNewKoolCreateCommand(t *testing.T) {
 	f.parser.(*presets.FakeParser).MockExists = true
 	f.KoolPreset.presetsParser.(*presets.FakeParser).MockExists = true
 	f.parser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"laravel": &presets.PresetConfig{
+		"laravel": {
 			Commands: map[string][]string{
-				"create": []string{"kool docker create command"},
+				"create": {"kool docker create command"},
 			},
 		},
 	}
@@ -110,7 +110,7 @@ func TestInvalidPresetCreateCommand(t *testing.T) {
 		t.Error("did not call Error")
 	}
 
-	expected := "Unknown preset invalid"
+	expected := "unknown preset invalid"
 	output := f.shell.(*shell.FakeShell).Err.Error()
 
 	if expected != output {
@@ -171,7 +171,7 @@ func TestNoCreateCommandsCreateCommand(t *testing.T) {
 
 	f.parser.(*presets.FakeParser).MockExists = true
 	f.parser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"laravel": &presets.PresetConfig{
+		"laravel": {
 			Commands: make(map[string][]string),
 		},
 	}
@@ -188,7 +188,7 @@ func TestNoCreateCommandsCreateCommand(t *testing.T) {
 		t.Error("did not call Error")
 	}
 
-	expected := "No create commands were found for preset laravel"
+	expected := "no create commands were found for preset laravel"
 	output := f.shell.(*shell.FakeShell).Err.Error()
 
 	if expected != output {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -48,10 +48,10 @@ func NewKoolDeploy() *KoolDeploy {
 	}
 }
 
-func init() {
+func AddKoolDeploy(root *cobra.Command) {
 	deployCmd := NewDeployCommand(NewKoolDeploy())
 
-	rootCmd.AddCommand(deployCmd)
+	root.AddCommand(deployCmd)
 	deployCmd.AddCommand(NewDeployExecCommand(NewKoolDeployExec()))
 	deployCmd.AddCommand(NewDeployDestroyCommand(NewKoolDeployDestroy()))
 }

--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -25,13 +25,13 @@ type KoolDocker struct {
 	dockerRun  builder.Command
 }
 
-func init() {
+func AddKoolDocker(root *cobra.Command) {
 	var (
 		docker    = NewKoolDocker()
 		dockerCmd = NewDockerCommand(docker)
 	)
 
-	rootCmd.AddCommand(dockerCmd)
+	root.AddCommand(dockerCmd)
 }
 
 // NewKoolDocker creates a new handler for docker logic

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -26,13 +26,13 @@ type KoolExec struct {
 	composeExec builder.Command
 }
 
-func init() {
+func AddKoolExec(root *cobra.Command) {
 	var (
 		exec    = NewKoolExec()
 		execCmd = NewExecCommand(exec)
 	)
 
-	rootCmd.AddCommand(execCmd)
+	root.AddCommand(execCmd)
 }
 
 // NewKoolExec creates a new handler for exec logic
@@ -47,7 +47,6 @@ func NewKoolExec() *KoolExec {
 
 // Execute runs the exec logic with incoming arguments.
 func (e *KoolExec) Execute(args []string) (err error) {
-	e.composeExec.Reset()
 	if asuser := e.env.Get("KOOL_ASUSER"); asuser != "" {
 		// we have a KOOL_ASUSER env; now we need to know whether
 		// the image of the target service have such user
@@ -64,7 +63,7 @@ func (e *KoolExec) Execute(args []string) (err error) {
 	}
 
 	if _, assert := e.composeExec.(*compose.DockerCompose); assert {
-		// let DockerCompose know about wheter we are under TTY or not
+		// let DockerCompose know about whether we are under TTY or not
 		e.composeExec.(*compose.DockerCompose).SetIsTTY(e.IsTerminal())
 	}
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -32,8 +32,8 @@ func NewKoolInfo() *KoolInfo {
 	}
 }
 
-func init() {
-	rootCmd.AddCommand(NewInfoCmd(NewKoolInfo()))
+func AddKoolInfo(root *cobra.Command) {
+	root.AddCommand(NewInfoCmd(NewKoolInfo()))
 }
 
 // Execute executes info logic

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,12 +1,15 @@
 package cmd
 
-import "github.com/gookit/color"
+import (
+	"github.com/gookit/color"
+	"github.com/spf13/cobra"
+)
 
-func init() {
+func AddKoolInit(root *cobra.Command) {
 	initCmd := NewPresetCommand(NewKoolPreset())
 	initCmd.Use = "init [PRESET]"
 	initCmd.Short = "[DEPRECATED] Proxies preset command"
 	initCmd.Deprecated = color.New(color.Yellow).Sprint("use the \"preset\" command instead.")
 
-	rootCmd.AddCommand(initCmd)
+	root.AddCommand(initCmd)
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -24,13 +24,13 @@ type KoolLogs struct {
 	logs builder.Command
 }
 
-func init() {
+func AddKoolLogs(root *cobra.Command) {
 	var (
 		logs    = NewKoolLogs()
 		logsCmd = NewLogsCommand(logs)
 	)
 
-	rootCmd.AddCommand(logsCmd)
+	root.AddCommand(logsCmd)
 }
 
 // NewKoolLogs creates a new handler for logs logic

--- a/cmd/preset.go
+++ b/cmd/preset.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"kool-dev/kool/cmd/compose"
 	"kool-dev/kool/cmd/parser"
 	"kool-dev/kool/cmd/presets"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 // KoolPreset holds handlers and functions to implement the preset command logic
@@ -23,13 +23,13 @@ type KoolPreset struct {
 	promptSelect   shell.PromptSelect
 }
 
-func init() {
+func AddKoolPreset(root *cobra.Command) {
 	var (
 		preset    = NewKoolPreset()
 		presetCmd = NewPresetCommand(preset)
 	)
 
-	rootCmd.AddCommand(presetCmd)
+	root.AddCommand(presetCmd)
 }
 
 // NewKoolPreset creates a new handler for preset logic
@@ -55,7 +55,7 @@ func (p *KoolPreset) Execute(args []string) (err error) {
 	}
 
 	if !p.presetsParser.Exists(preset) {
-		err = fmt.Errorf("Unknown preset %s", preset)
+		err = fmt.Errorf("unknown preset %s", preset)
 		return
 	}
 
@@ -75,7 +75,7 @@ func (p *KoolPreset) Execute(args []string) (err error) {
 	}
 
 	if fileError, err = p.presetsParser.WriteFiles(preset); err != nil {
-		err = fmt.Errorf("Failed to write preset file %s: %v", fileError, err)
+		err = fmt.Errorf("failed to write preset file %s: %v", fileError, err)
 		return
 	}
 
@@ -160,7 +160,7 @@ func (p *KoolPreset) setDefaultTemplates(config *presets.PresetConfig) (err erro
 
 	for _, template := range config.Templates {
 		if err = p.templateParser.Parse(allTemplates[template.Key][template.Template]); err != nil {
-			err = fmt.Errorf("Failed to load default preset templates: %v", err)
+			err = fmt.Errorf("failed to load default preset templates: %v", err)
 			return
 		}
 
@@ -207,7 +207,7 @@ func (p *KoolPreset) customizeCompose(preset string, config *presets.PresetConfi
 
 			if selectedOption != "none" {
 				if err = p.templateParser.Parse(optionTemplate[selectedOption]); err != nil {
-					err = fmt.Errorf("Failed to write preset file docker-compose.yml: %v", err)
+					err = fmt.Errorf("failed to write preset file docker-compose.yml: %v", err)
 					return
 				}
 
@@ -226,7 +226,7 @@ func (p *KoolPreset) customizeCompose(preset string, config *presets.PresetConfi
 		}
 
 		if newCompose, err = p.composeParser.String(); err != nil {
-			err = fmt.Errorf("Failed to write preset file docker-compose.yml: %v", err)
+			err = fmt.Errorf("failed to write preset file docker-compose.yml: %v", err)
 			return
 		}
 
@@ -262,7 +262,7 @@ func (p *KoolPreset) customizeKoolYaml(preset string, config *presets.PresetConf
 
 			if selectedOption != "none" {
 				if err = p.templateParser.Parse(optionTemplate[selectedOption]); err != nil {
-					err = fmt.Errorf("Failed to write preset file kool.yml: %v", err)
+					err = fmt.Errorf("failed to write preset file kool.yml: %v", err)
 					return
 				}
 
@@ -273,7 +273,7 @@ func (p *KoolPreset) customizeKoolYaml(preset string, config *presets.PresetConf
 		}
 
 		if newKoolYaml, err = p.koolYamlParser.String(); err != nil {
-			err = fmt.Errorf("Failed to write preset file kool.yml: %v", err)
+			err = fmt.Errorf("failed to write preset file kool.yml: %v", err)
 			return
 		}
 

--- a/cmd/preset_test.go
+++ b/cmd/preset_test.go
@@ -93,7 +93,7 @@ func TestPresetCommand(t *testing.T) {
 	f := newFakeKoolPreset()
 	f.presetsParser.(*presets.FakeParser).MockExists = true
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"laravel": &presets.PresetConfig{},
+		"laravel": {},
 	}
 
 	cmd := NewPresetCommand(f)
@@ -177,7 +177,7 @@ func TestInvalidScriptPresetCommand(t *testing.T) {
 		t.Error("did not call Error")
 	}
 
-	expected := "Unknown preset invalid"
+	expected := "unknown preset invalid"
 	output := f.shell.(*shell.FakeShell).Err.Error()
 
 	if expected != output {
@@ -194,7 +194,7 @@ func TestExistingFilesPresetCommand(t *testing.T) {
 	f.presetsParser.(*presets.FakeParser).MockExists = true
 	f.presetsParser.(*presets.FakeParser).MockFoundFiles = []string{"kool.yml"}
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"laravel": &presets.PresetConfig{},
+		"laravel": {},
 	}
 
 	cmd := NewPresetCommand(f)
@@ -230,7 +230,7 @@ func TestWriteErrorPresetCommand(t *testing.T) {
 	f.presetsParser.(*presets.FakeParser).MockExists = true
 	f.presetsParser.(*presets.FakeParser).MockError = errors.New("write error")
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"laravel": &presets.PresetConfig{},
+		"laravel": {},
 	}
 
 	cmd := NewPresetCommand(f)
@@ -245,7 +245,7 @@ func TestWriteErrorPresetCommand(t *testing.T) {
 		t.Error("did not call Error")
 	}
 
-	expected := "Failed to write preset file : write error"
+	expected := "failed to write preset file : write error"
 	output := f.shell.(*shell.FakeShell).Err.Error()
 
 	if output != expected {
@@ -269,7 +269,7 @@ func TestNoArgsPresetCommand(t *testing.T) {
 	f.presetsParser.(*presets.FakeParser).MockPresets = []string{"laravel"}
 	f.presetsParser.(*presets.FakeParser).MockExists = true
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"laravel": &presets.PresetConfig{},
+		"laravel": {},
 	}
 
 	cmd := NewPresetCommand(f)
@@ -295,7 +295,7 @@ func TestFailingLanguageNoArgsPresetCommand(t *testing.T) {
 	f.presetsParser.(*presets.FakeParser).MockLanguages = []string{"php"}
 	f.presetsParser.(*presets.FakeParser).MockPresets = []string{"laravel"}
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"laravel": &presets.PresetConfig{},
+		"laravel": {},
 	}
 
 	mockError := make(map[string]error)
@@ -334,7 +334,7 @@ func TestFailingPresetNoArgsPresetCommand(t *testing.T) {
 	f.presetsParser.(*presets.FakeParser).MockLanguages = []string{"php"}
 	f.presetsParser.(*presets.FakeParser).MockPresets = []string{"laravel"}
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"laravel": &presets.PresetConfig{},
+		"laravel": {},
 	}
 
 	mockAnswer := make(map[string]string)
@@ -436,13 +436,13 @@ func TestCustomDockerComposePresetCommand(t *testing.T) {
 
 	config := &presets.PresetConfig{
 		Questions: map[string][]presets.PresetConfigQuestion{
-			"compose": []presets.PresetConfigQuestion{
+			"compose": {
 				presets.PresetConfigQuestion{
 					Key:     "database",
 					Message: "What database service do you want to use",
 					Options: []presets.PresetConfigQuestionOption{
-						presets.PresetConfigQuestionOption{Name: "mysql", Template: "mysql.yml"},
-						presets.PresetConfigQuestionOption{Name: "postgresql", Template: "postgresql.yml"},
+						{Name: "mysql", Template: "mysql.yml"},
+						{Name: "postgresql", Template: "postgresql.yml"},
 					},
 				},
 			},
@@ -455,7 +455,7 @@ func TestCustomDockerComposePresetCommand(t *testing.T) {
 		"What database service do you want to use": "mysql",
 	}
 	f.presetsParser.(*presets.FakeParser).MockTemplates = map[string]map[string]string{
-		"database": map[string]string{
+		"database": {
 			"mysql.yml": mysqlTemplate,
 		},
 	}
@@ -469,7 +469,7 @@ func TestCustomDockerComposePresetCommand(t *testing.T) {
 	}
 
 	f.templateParser.(*templates.FakeParser).MockGetScripts = map[string][]string{
-		"script": []string{"script"},
+		"script": {"script"},
 	}
 
 	cmd := NewPresetCommand(f)
@@ -515,13 +515,13 @@ func TestCustomDockerComposeErrorTemplateParsePresetCommand(t *testing.T) {
 
 	config := &presets.PresetConfig{
 		Questions: map[string][]presets.PresetConfigQuestion{
-			"compose": []presets.PresetConfigQuestion{
+			"compose": {
 				presets.PresetConfigQuestion{
 					Key:     "database",
 					Message: "What database service do you want to use",
 					Options: []presets.PresetConfigQuestionOption{
-						presets.PresetConfigQuestionOption{Name: "mysql", Template: "mysql.yml"},
-						presets.PresetConfigQuestionOption{Name: "postgresql", Template: "postgresql.yml"},
+						{Name: "mysql", Template: "mysql.yml"},
+						{Name: "postgresql", Template: "postgresql.yml"},
 					},
 				},
 			},
@@ -534,7 +534,7 @@ func TestCustomDockerComposeErrorTemplateParsePresetCommand(t *testing.T) {
 		"What database service do you want to use": "mysql",
 	}
 	f.presetsParser.(*presets.FakeParser).MockTemplates = map[string]map[string]string{
-		"database": map[string]string{
+		"database": {
 			"mysql.yml": mysqlTemplate,
 		},
 	}
@@ -555,7 +555,7 @@ func TestCustomDockerComposeErrorTemplateParsePresetCommand(t *testing.T) {
 
 	err := f.shell.(*shell.FakeShell).Err
 
-	expectedErr := "Failed to write preset file docker-compose.yml: parse error"
+	expectedErr := "failed to write preset file docker-compose.yml: parse error"
 
 	if err == nil {
 		t.Error("expecting an error, got none")
@@ -574,14 +574,14 @@ func TestCustomDockerNoneOptionComposePresetCommand(t *testing.T) {
 
 	config := &presets.PresetConfig{
 		Questions: map[string][]presets.PresetConfigQuestion{
-			"compose": []presets.PresetConfigQuestion{
+			"compose": {
 				presets.PresetConfigQuestion{
 					Key:     "database",
 					Message: "What database service do you want to use",
 					Options: []presets.PresetConfigQuestionOption{
-						presets.PresetConfigQuestionOption{Name: "mysql", Template: "mysql.yml"},
-						presets.PresetConfigQuestionOption{Name: "postgresql", Template: "postgresql.yml"},
-						presets.PresetConfigQuestionOption{Name: "none", Template: "none"},
+						{Name: "mysql", Template: "mysql.yml"},
+						{Name: "postgresql", Template: "postgresql.yml"},
+						{Name: "none", Template: "none"},
 					},
 				},
 			},
@@ -594,7 +594,7 @@ func TestCustomDockerNoneOptionComposePresetCommand(t *testing.T) {
 		"What database service do you want to use": "none",
 	}
 	f.presetsParser.(*presets.FakeParser).MockTemplates = map[string]map[string]string{
-		"database": map[string]string{
+		"database": {
 			"mysql.yml": mysqlTemplate,
 		},
 	}
@@ -639,13 +639,13 @@ func TestErrorAskForServicePresetCommand(t *testing.T) {
 
 	config := &presets.PresetConfig{
 		Questions: map[string][]presets.PresetConfigQuestion{
-			"compose": []presets.PresetConfigQuestion{
+			"compose": {
 				presets.PresetConfigQuestion{
 					Key:     "database",
 					Message: "What database service do you want to use",
 					Options: []presets.PresetConfigQuestionOption{
-						presets.PresetConfigQuestionOption{Name: "mysql", Template: "mysql.yml"},
-						presets.PresetConfigQuestionOption{Name: "postgresql", Template: "postgresql.yml"},
+						{Name: "mysql", Template: "mysql.yml"},
+						{Name: "postgresql", Template: "postgresql.yml"},
 					},
 				},
 			},
@@ -687,13 +687,13 @@ func TestErrorComposeStringPresetCommand(t *testing.T) {
 
 	config := &presets.PresetConfig{
 		Questions: map[string][]presets.PresetConfigQuestion{
-			"compose": []presets.PresetConfigQuestion{
+			"compose": {
 				presets.PresetConfigQuestion{
 					Key:     "database",
 					Message: "What database service do you want to use",
 					Options: []presets.PresetConfigQuestionOption{
-						presets.PresetConfigQuestionOption{Name: "mysql", Template: "mysql.yml"},
-						presets.PresetConfigQuestionOption{Name: "postgresql", Template: "postgresql.yml"},
+						{Name: "mysql", Template: "mysql.yml"},
+						{Name: "postgresql", Template: "postgresql.yml"},
 					},
 				},
 			},
@@ -706,7 +706,7 @@ func TestErrorComposeStringPresetCommand(t *testing.T) {
 		"What database service do you want to use": "mysql",
 	}
 	f.presetsParser.(*presets.FakeParser).MockTemplates = map[string]map[string]string{
-		"database": map[string]string{
+		"database": {
 			"mysql.yml": mysqlTemplate,
 		},
 	}
@@ -729,8 +729,8 @@ func TestErrorComposeStringPresetCommand(t *testing.T) {
 
 	if err == nil {
 		t.Error("expecting an error, got none")
-	} else if err.Error() != "Failed to write preset file docker-compose.yml: compose string error" {
-		t.Errorf("expecting error 'Failed to write preset file docker-compose.yml: compose string error', got %v", err)
+	} else if err.Error() != "failed to write preset file docker-compose.yml: compose string error" {
+		t.Errorf("expecting error 'failed to write preset file docker-compose.yml: compose string error', got %v", err)
 	}
 }
 
@@ -782,9 +782,9 @@ func TestDefaultTemplatesPresetCommand(t *testing.T) {
 	f.presetsParser.(*presets.FakeParser).MockExists = true
 
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"preset": &presets.PresetConfig{
+		"preset": {
 			Templates: []presets.PresetConfigTemplate{
-				presets.PresetConfigTemplate{
+				{
 					Key:      "scripts",
 					Template: "template.yml",
 				},
@@ -793,7 +793,7 @@ func TestDefaultTemplatesPresetCommand(t *testing.T) {
 	}
 
 	f.presetsParser.(*presets.FakeParser).MockTemplates = map[string]map[string]string{
-		"scripts": map[string]string{
+		"scripts": {
 			"template.yml": defaultTemplate,
 		},
 	}
@@ -809,7 +809,7 @@ func TestDefaultTemplatesPresetCommand(t *testing.T) {
 	}
 
 	f.templateParser.(*templates.FakeParser).MockGetScripts = map[string][]string{
-		"script": []string{"script"},
+		"script": {"script"},
 	}
 
 	cmd := NewPresetCommand(f)
@@ -868,9 +868,9 @@ func TestErrorDefaultTemplatesPresetCommand(t *testing.T) {
 	f.presetsParser.(*presets.FakeParser).MockExists = true
 
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"preset": &presets.PresetConfig{
+		"preset": {
 			Templates: []presets.PresetConfigTemplate{
-				presets.PresetConfigTemplate{
+				{
 					Key:      "scripts",
 					Template: "template.yml",
 				},
@@ -879,7 +879,7 @@ func TestErrorDefaultTemplatesPresetCommand(t *testing.T) {
 	}
 
 	f.presetsParser.(*presets.FakeParser).MockTemplates = map[string]map[string]string{
-		"scripts": map[string]string{
+		"scripts": {
 			"template.yml": defaultTemplate,
 		},
 	}
@@ -902,8 +902,8 @@ func TestErrorDefaultTemplatesPresetCommand(t *testing.T) {
 
 	if err == nil {
 		t.Error("expecting an error, got none")
-	} else if err.Error() != "Failed to load default preset templates: template parse error" {
-		t.Errorf("expecting error 'Failed to load default preset templates: template parse error', got %v", err)
+	} else if err.Error() != "failed to load default preset templates: template parse error" {
+		t.Errorf("expecting error 'failed to load default preset templates: template parse error', got %v", err)
 	}
 
 	if !f.exiter.(*shell.FakeExiter).Exited() {
@@ -923,19 +923,19 @@ func TestCustomKoolYmlPresetCommand(t *testing.T) {
 	f.presetsParser.(*presets.FakeParser).MockExists = true
 
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"preset": &presets.PresetConfig{
+		"preset": {
 			Questions: map[string][]presets.PresetConfigQuestion{
-				"kool": []presets.PresetConfigQuestion{
+				"kool": {
 					presets.PresetConfigQuestion{
 						Key:           "scripts",
 						DefaultAnswer: "npm",
 						Message:       "What javascript package manager do you want to use",
 						Options: []presets.PresetConfigQuestionOption{
-							presets.PresetConfigQuestionOption{
+							{
 								Name:     "npm",
 								Template: "npm.yml",
 							},
-							presets.PresetConfigQuestionOption{
+							{
 								Name:     "yarn",
 								Template: "yarn.yml",
 							},
@@ -951,14 +951,14 @@ func TestCustomKoolYmlPresetCommand(t *testing.T) {
 	}
 
 	f.presetsParser.(*presets.FakeParser).MockTemplates = map[string]map[string]string{
-		"scripts": map[string]string{
+		"scripts": {
 			"yarn.yml": yarnTemplate,
 		},
 	}
 
 	f.templateParser.(*templates.FakeParser).MockGetScripts = map[string][]string{
-		"yarn":       []string{"kool docker kooldev/node:14 yarn"},
-		"node-setup": []string{"kool run yarn install", "kool run yarn dev"},
+		"yarn":       {"kool docker kooldev/node:14 yarn"},
+		"node-setup": {"kool run yarn install", "kool run yarn dev"},
 	}
 
 	f.koolYamlParser.(*parser.FakeKoolYaml).MockString = "kool content"
@@ -1010,19 +1010,19 @@ func TestAskErrorCustomKoolYmlPresetCommand(t *testing.T) {
 	f.presetsParser.(*presets.FakeParser).MockExists = true
 
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"preset": &presets.PresetConfig{
+		"preset": {
 			Questions: map[string][]presets.PresetConfigQuestion{
-				"kool": []presets.PresetConfigQuestion{
+				"kool": {
 					presets.PresetConfigQuestion{
 						Key:           "scripts",
 						DefaultAnswer: "npm",
 						Message:       "What javascript package manager do you want to use",
 						Options: []presets.PresetConfigQuestionOption{
-							presets.PresetConfigQuestionOption{
+							{
 								Name:     "npm",
 								Template: "npm.yml",
 							},
-							presets.PresetConfigQuestionOption{
+							{
 								Name:     "yarn",
 								Template: "yarn.yml",
 							},
@@ -1034,7 +1034,7 @@ func TestAskErrorCustomKoolYmlPresetCommand(t *testing.T) {
 	}
 
 	f.presetsParser.(*presets.FakeParser).MockTemplates = map[string]map[string]string{
-		"scripts": map[string]string{
+		"scripts": {
 			"yarn.yml": "template",
 		},
 	}
@@ -1074,19 +1074,19 @@ func TestTemplateParseErrorCustomKoolYmlPresetCommand(t *testing.T) {
 	f.presetsParser.(*presets.FakeParser).MockExists = true
 
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"preset": &presets.PresetConfig{
+		"preset": {
 			Questions: map[string][]presets.PresetConfigQuestion{
-				"kool": []presets.PresetConfigQuestion{
+				"kool": {
 					presets.PresetConfigQuestion{
 						Key:           "scripts",
 						DefaultAnswer: "npm",
 						Message:       "What javascript package manager do you want to use",
 						Options: []presets.PresetConfigQuestionOption{
-							presets.PresetConfigQuestionOption{
+							{
 								Name:     "npm",
 								Template: "npm.yml",
 							},
-							presets.PresetConfigQuestionOption{
+							{
 								Name:     "yarn",
 								Template: "yarn.yml",
 							},
@@ -1098,7 +1098,7 @@ func TestTemplateParseErrorCustomKoolYmlPresetCommand(t *testing.T) {
 	}
 
 	f.presetsParser.(*presets.FakeParser).MockTemplates = map[string]map[string]string{
-		"scripts": map[string]string{
+		"scripts": {
 			"yarn.yml": "template",
 		},
 	}
@@ -1125,8 +1125,8 @@ func TestTemplateParseErrorCustomKoolYmlPresetCommand(t *testing.T) {
 
 	if err == nil {
 		t.Error("expecting an error, got none")
-	} else if err.Error() != "Failed to write preset file kool.yml: parse error" {
-		t.Errorf("expecting error 'Failed to write preset file kool.yml: parse error', got %v", err)
+	} else if err.Error() != "failed to write preset file kool.yml: parse error" {
+		t.Errorf("expecting error 'failed to write preset file kool.yml: parse error', got %v", err)
 	}
 
 	if !f.exiter.(*shell.FakeExiter).Exited() {
@@ -1146,19 +1146,19 @@ func TestStringErrorCustomKoolYmlPresetCommand(t *testing.T) {
 	f.presetsParser.(*presets.FakeParser).MockExists = true
 
 	f.presetsParser.(*presets.FakeParser).MockConfig = map[string]*presets.PresetConfig{
-		"preset": &presets.PresetConfig{
+		"preset": {
 			Questions: map[string][]presets.PresetConfigQuestion{
-				"kool": []presets.PresetConfigQuestion{
+				"kool": {
 					presets.PresetConfigQuestion{
 						Key:           "scripts",
 						DefaultAnswer: "npm",
 						Message:       "What javascript package manager do you want to use",
 						Options: []presets.PresetConfigQuestionOption{
-							presets.PresetConfigQuestionOption{
+							{
 								Name:     "npm",
 								Template: "npm.yml",
 							},
-							presets.PresetConfigQuestionOption{
+							{
 								Name:     "yarn",
 								Template: "yarn.yml",
 							},
@@ -1174,14 +1174,14 @@ func TestStringErrorCustomKoolYmlPresetCommand(t *testing.T) {
 	}
 
 	f.presetsParser.(*presets.FakeParser).MockTemplates = map[string]map[string]string{
-		"scripts": map[string]string{
+		"scripts": {
 			"yarn.yml": yarnTemplate,
 		},
 	}
 
 	f.templateParser.(*templates.FakeParser).MockGetScripts = map[string][]string{
-		"yarn":       []string{"kool docker kooldev/node:14 yarn"},
-		"node-setup": []string{"kool run yarn install", "kool run yarn dev"},
+		"yarn":       {"kool docker kooldev/node:14 yarn"},
+		"node-setup": {"kool run yarn install", "kool run yarn dev"},
 	}
 
 	f.koolYamlParser.(*parser.FakeKoolYaml).MockStringError = errors.New("string error")
@@ -1202,8 +1202,8 @@ func TestStringErrorCustomKoolYmlPresetCommand(t *testing.T) {
 
 	if err == nil {
 		t.Error("expecting an error, got none")
-	} else if err.Error() != "Failed to write preset file kool.yml: string error" {
-		t.Errorf("expecting error 'Failed to write preset file kool.yml: string error', got %v", err)
+	} else if err.Error() != "failed to write preset file kool.yml: string error" {
+		t.Errorf("expecting error 'failed to write preset file kool.yml: string error', got %v", err)
 	}
 
 	if !f.exiter.(*shell.FakeExiter).Exited() {

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -14,6 +14,6 @@ func NewRestartCommand(stop KoolService, start KoolService) *cobra.Command {
 	}
 }
 
-func init() {
-	rootCmd.AddCommand(NewRestartCommand(NewKoolStop(), NewKoolStart()))
+func AddKoolRestart(root *cobra.Command) {
+	root.AddCommand(NewRestartCommand(NewKoolStop(), NewKoolStart()))
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -283,3 +283,44 @@ func TestMultipleRecursiveCall(t *testing.T) {
 		t.Errorf("fail calling recursive command: %v", err)
 	}
 }
+
+func TestAddCommands(t *testing.T) {
+	root := NewRootCmd(environment.NewFakeEnvStorage())
+
+	AddCommands(root)
+
+	var subcommands map[string]bool = map[string]bool{
+		"completion":  false,
+		"create":      false,
+		"deploy":      false,
+		"docker":      false,
+		"exec":        false,
+		"info":        false,
+		"init":        false,
+		"logs":        false,
+		"preset":      false,
+		"restart":     false,
+		"run":         false,
+		"self-update": false,
+		"share":       false,
+		"start":       false,
+		"status":      false,
+		"stop":        false,
+	}
+
+	for _, subCmd := range root.Commands() {
+		name := subCmd.Name()
+		if _, ok := subcommands[name]; !ok {
+			t.Errorf("unexpected command was added: %s", name)
+			continue
+		}
+
+		subcommands[name] = true
+	}
+
+	for cmd, added := range subcommands {
+		if !added {
+			t.Errorf("expected command is missing: %s", cmd)
+		}
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -25,13 +25,13 @@ var ErrExtraArguments = errors.New("error: you cannot pass in extra arguments to
 // ErrKoolScriptNotFound means that the given script was not found
 var ErrKoolScriptNotFound = errors.New("script was not found in any kool.yml file")
 
-func init() {
+func AddKoolRun(root *cobra.Command) {
 	var (
 		run    = NewKoolRun()
 		runCmd = NewRunCommand(run)
 	)
 
-	rootCmd.AddCommand(runCmd)
+	root.AddCommand(runCmd)
 
 	SetRunUsageFunc(run, runCmd)
 }

--- a/cmd/self-update.go
+++ b/cmd/self-update.go
@@ -14,13 +14,13 @@ type KoolSelfUpdate struct {
 	updater updater.Updater
 }
 
-func init() {
+func AddKoolSelfUpdate(root *cobra.Command) {
 	var (
 		selfUpdate    = NewKoolSelfUpdate()
 		selfUpdateCmd = NewSelfUpdateCommand(selfUpdate)
 	)
 
-	rootCmd.AddCommand(selfUpdateCmd)
+	root.AddCommand(selfUpdateCmd)
 }
 
 // NewKoolSelfUpdate creates a new handler for self-update logic with default dependencies

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -36,13 +36,13 @@ type KoolShare struct {
 	share  builder.Command
 }
 
-func init() {
+func AddKoolShare(root *cobra.Command) {
 	var (
 		share    = NewKoolShare()
 		shareCmd = NewShareCommand(share)
 	)
 
-	rootCmd.AddCommand(shareCmd)
+	root.AddCommand(shareCmd)
 }
 
 // NewKoolShare creates a new handler for sharing local environment with default dependencies

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -44,8 +44,8 @@ func NewKoolStart() *KoolStart {
 	}
 }
 
-func init() {
-	rootCmd.AddCommand(NewStartCommand(NewKoolStart()))
+func AddKoolStart(root *cobra.Command) {
+	root.AddCommand(NewStartCommand(NewKoolStart()))
 }
 
 // Execute runs the start logic with incoming arguments.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -34,13 +34,13 @@ type statusService struct {
 	err                   error
 }
 
-func init() {
+func AddKoolStatus(root *cobra.Command) {
 	var (
 		status    = NewKoolStatus()
 		statusCmd = NewStatusCommand(status)
 	)
 
-	rootCmd.AddCommand(statusCmd)
+	root.AddCommand(statusCmd)
 }
 
 // NewKoolStatus creates a new handler for status logic

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -23,13 +23,13 @@ type KoolStop struct {
 	rm    builder.Command
 }
 
-func init() {
+func AddKoolStop(root *cobra.Command) {
 	var (
 		stop    = NewKoolStop()
 		stopCmd = NewStopCommand(stop)
 	)
 
-	rootCmd.AddCommand(stopCmd)
+	root.AddCommand(stopCmd)
 }
 
 // NewKoolStop creates a new handler for stop logic with default dependencies


### PR DESCRIPTION
| Issue | #290 |
| -----: | :-----: |
| :beetle: Bug Fix | Yes|
| :trophy: Feature | No |
| :pencil: Refactor | Yes |
| :open_book: Documentation | No |
| :warning: Break Change | No |

**Description**
Create a new instance of kool when it runs itself on a script, reseting the flags and shell environment.

---
