### PR TITLE
Environment Variable flags to run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,9 +31,6 @@ var ErrExtraArguments = errors.New("error: you cannot pass in extra arguments to
 // ErrKoolScriptNotFound means that the given script was not found
 var ErrKoolScriptNotFound = errors.New("script was not found in any kool.yml file")
 
-// ErrExtraEnvMultiLines Extra environment variables error
-var ErrExtraEnvMultiLines = errors.New("error: you cannot pass in extra environment variables to multiple commands scripts")
-
 func AddKoolRun(root *cobra.Command) {
 	var (
 		run    = NewKoolRun()
@@ -79,11 +76,6 @@ func (r *KoolRun) Execute(originalArgs []string) (err error) {
 
 	if len(args) > 0 && len(r.commands) > 1 {
 		err = ErrExtraArguments
-		return
-	}
-
-	if len(r.Flags.EnvVariables) > 0 && len(r.commands) > 1 {
-		err = ErrExtraEnvMultiLines
 		return
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -11,9 +11,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// KoolRunFlags holds the flags for the run command
+type KoolRunFlags struct {
+	EnvVariables []string
+}
+
 // KoolRun holds handlers and functions to implement the run command logic
 type KoolRun struct {
 	DefaultKoolService
+	Flags    *KoolRunFlags
 	parser   parser.Parser
 	env      environment.EnvStorage
 	commands []builder.Command
@@ -24,6 +30,9 @@ var ErrExtraArguments = errors.New("error: you cannot pass in extra arguments to
 
 // ErrKoolScriptNotFound means that the given script was not found
 var ErrKoolScriptNotFound = errors.New("script was not found in any kool.yml file")
+
+// ErrExtraEnvMultiLines Extra environment variables error
+var ErrExtraEnvMultiLines = errors.New("error: you cannot pass in extra environment variables to multiple commands scripts")
 
 func AddKoolRun(root *cobra.Command) {
 	var (
@@ -40,6 +49,7 @@ func AddKoolRun(root *cobra.Command) {
 func NewKoolRun() *KoolRun {
 	return &KoolRun{
 		*newDefaultKoolService(),
+		&KoolRunFlags{[]string{}},
 		parser.NewParser(),
 		environment.NewEnvStorage(),
 		[]builder.Command{},
@@ -58,14 +68,8 @@ func (r *KoolRun) Execute(originalArgs []string) (err error) {
 	// look for kool.yml on kool folder within user home directory
 	_ = r.parser.AddLookupPath(path.Join(r.env.Get("HOME"), "kool"))
 
-	if r.commands, err = r.parser.Parse(script); err != nil {
-		if parser.IsMultipleDefinedScriptError(err) {
-			// we should just warn the user about multiple finds for the script
-			r.Warning("Attention: the script was found in more than one kool.yml file")
-			err = nil
-		} else {
-			return
-		}
+	if err = r.parseScript(script); err != nil {
+		return
 	}
 
 	if len(r.commands) == 0 {
@@ -75,6 +79,11 @@ func (r *KoolRun) Execute(originalArgs []string) (err error) {
 
 	if len(args) > 0 && len(r.commands) > 1 {
 		err = ErrExtraArguments
+		return
+	}
+
+	if len(r.Flags.EnvVariables) > 0 && len(r.commands) > 1 {
+		err = ErrExtraEnvMultiLines
 		return
 	}
 
@@ -106,6 +115,8 @@ func NewRunCommand(run *KoolRun) (runCmd *cobra.Command) {
 		},
 	}
 
+	runCmd.Flags().StringArrayVarP(&run.Flags.EnvVariables, "env", "e", []string{}, "Environment variables.")
+
 	// after a non-flag arg, stop parsing flags
 	runCmd.Flags().SetInterspersed(false)
 
@@ -116,6 +127,30 @@ func NewRunCommand(run *KoolRun) (runCmd *cobra.Command) {
 func SetRunUsageFunc(run *KoolRun, runCmd *cobra.Command) {
 	originalUsageText := runCmd.UsageString()
 	runCmd.SetUsageFunc(getRunUsageFunc(run, originalUsageText))
+}
+
+func (r *KoolRun) parseScript(script string) (err error) {
+	var originalEnvs map[string]string = make(map[string]string)
+
+	for _, envVar := range r.Flags.EnvVariables {
+		pair := strings.SplitN(envVar, "=", 2)
+		originalEnvs[pair[0]] = r.env.Get(pair[0])
+		r.env.Set(pair[0], pair[1])
+	}
+
+	defer func() {
+		for k, v := range originalEnvs {
+			r.env.Set(k, v)
+		}
+	}()
+
+	if r.commands, err = r.parser.Parse(script); err != nil && parser.IsMultipleDefinedScriptError(err) {
+		// we should just warn the user about multiple finds for the script
+		r.Warning("Attention: the script was found in more than one kool.yml file")
+		err = nil
+	}
+
+	return
 }
 
 func getRunUsageFunc(run *KoolRun, originalUsageText string) func(*cobra.Command) error {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -579,27 +579,3 @@ func TestNewRunCommandWithEnvVariable(t *testing.T) {
 		t.Errorf("expected to set '$VAR_TEST' to an empty value after using it, did set to '%s'", history[0])
 	}
 }
-
-func TestNewRunCommandExtraEnvVarsError(t *testing.T) {
-	fakeParsedCommands := []builder.Command{&builder.FakeCommand{}, &builder.FakeCommand{}}
-	f := newFakeKoolRun(fakeParsedCommands, nil)
-	cmd := NewRunCommand(f)
-
-	cmd.SetArgs([]string{"--env=VAR_TEST=1", "script"})
-
-	if err := cmd.Execute(); err != nil {
-		t.Errorf("unexpected error executing run command; error: %v", err)
-	}
-
-	if !f.shell.(*shell.FakeShell).CalledError {
-		t.Error("did not call Error for extra environment variables")
-	}
-
-	if gotError := f.shell.(*shell.FakeShell).Err; !errors.Is(gotError, ErrExtraEnvMultiLines) {
-		t.Errorf("expecting error '%v', got '%v'", ErrExtraEnvMultiLines, gotError)
-	}
-
-	if !f.exiter.(*shell.FakeExiter).Exited() {
-		t.Error("got an extra arguments error, but command did not exit")
-	}
-}

--- a/docs/4-Commands/kool-run.md
+++ b/docs/4-Commands/kool-run.md
@@ -9,7 +9,8 @@ kool run [script] [command] [flags]
 ### Options
 
 ```
-  -h, --help   help for run
+  -e, --env stringArray   Environment variables.
+  -h, --help              help for run
 ```
 
 ### Options inherited from parent commands

--- a/environment/fake_env_storage.go
+++ b/environment/fake_env_storage.go
@@ -6,14 +6,16 @@ import (
 
 // FakeEnvStorage holds fake environment variables
 type FakeEnvStorage struct {
-	Envs       map[string]string
-	CalledLoad bool
+	Envs        map[string]string
+	CalledLoad  bool
+	EnvsHistory map[string][]string
 }
 
 // NewFakeEnvStorage creates a new FakeEnvStorage
 func NewFakeEnvStorage() *FakeEnvStorage {
 	return &FakeEnvStorage{
-		Envs: make(map[string]string),
+		Envs:        make(map[string]string),
+		EnvsHistory: make(map[string][]string),
 	}
 }
 
@@ -25,6 +27,7 @@ func (f *FakeEnvStorage) Get(key string) string {
 // Set set environment variable value (fake behavior)
 func (f *FakeEnvStorage) Set(key string, value string) {
 	f.Envs[key] = value
+	f.EnvsHistory[key] = append(f.EnvsHistory[key], value)
 }
 
 // Load load environment file (fake behavior)

--- a/environment/fake_env_storage_test.go
+++ b/environment/fake_env_storage_test.go
@@ -76,3 +76,25 @@ func TestIsTrueNonBooleanStringFakeEnvStorage(t *testing.T) {
 		t.Error("Environment variable non-boolean value should not be true.")
 	}
 }
+
+func TestEnvsHistoryFakeEnvStorage(t *testing.T) {
+	var (
+		history []string
+		hasKey  bool
+	)
+
+	f := NewFakeEnvStorage()
+
+	f.Set("test-env", "first-value")
+
+	history, hasKey = f.EnvsHistory["test-env"]
+
+	if !hasKey || len(history) == 0 {
+		t.Error("environment variable was not added to history")
+		return
+	}
+
+	if history[0] != "first-value" {
+		t.Errorf("expecting to get 'first-value' in history, got %s", history[0])
+	}
+}


### PR DESCRIPTION
| Issue | # |
| -----: | :-----: |
| :beetle: Bug Fix | No |
| :trophy: Feature | Yes|
| :pencil: Refactor | No |
| :open_book: Documentation | No |
| :warning: Break Change | No |

**Description**
This Pull Request adds a new flag that allows `kool run` command to set environment variables at runtime

---
