### PR TITLE
warning about development build

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,8 @@ type CobraRunFN func(*cobra.Command, []string)
 // AddCommandsFN function to add subcommands
 type AddCommandsFN func(*cobra.Command)
 
+var hasWarnedDevelopmentVersion = false
+
 var AddCommands AddCommandsFN = func(root *cobra.Command) {
 	AddKoolCompletion(root)
 	AddKoolCreate(root)
@@ -33,7 +35,10 @@ var AddCommands AddCommandsFN = func(root *cobra.Command) {
 	AddKoolStop(root)
 }
 
-var version string = "0.0.0-dev"
+// DEV_VERSION holds the static version shown for development time builds
+const DEV_VERSION = "0.0.0-dev"
+
+var version string = DEV_VERSION
 
 var rootCmd = NewRootCmd(environment.NewEnvStorage())
 
@@ -51,9 +56,14 @@ tool helping you from project creation through deployment.
 Complete documentation is available at https://kool.dev/docs`,
 		Version:           version,
 		DisableAutoGenTag: true,
-		PersistentPreRun: func(cmf *cobra.Command, args []string) {
-			if verbose := cmf.Flags().Lookup("verbose"); verbose != nil && verbose.Value.String() == "true" {
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if verbose := cmd.Flags().Lookup("verbose"); verbose != nil && verbose.Value.String() == "true" {
 				env.Set("KOOL_VERBOSE", verbose.Value.String())
+			}
+
+			if !hasWarnedDevelopmentVersion && version == DEV_VERSION && shell.NewTerminalChecker().IsTerminal(cmd.OutOrStdout()) {
+				shell.NewShell().Warning("Warning: you are executing a development version of kool.")
+				hasWarnedDevelopmentVersion = true
 			}
 		},
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package cmd
 
 import (

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/creack/pty"
 	"github.com/spf13/cobra"
 )
 
@@ -322,5 +323,73 @@ func TestAddCommands(t *testing.T) {
 		if !added {
 			t.Errorf("expected command is missing: %s", cmd)
 		}
+	}
+}
+
+func TestDevelopmentVersionWarning(t *testing.T) {
+	fakeEnv := environment.NewFakeEnvStorage()
+	root := NewRootCmd(fakeEnv)
+
+	fakecmd := &cobra.Command{
+		Use: "fakecmd",
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(fakecmd)
+
+	// default test NOT A TTY
+	b := bytes.NewBufferString("")
+	root.SetOut(b)
+
+	root.SetArgs([]string{"fakecmd"})
+	version = DEV_VERSION
+	if err := root.Execute(); err != nil {
+		t.Errorf("unexpected error executing command; error: %v", err)
+	}
+
+	var (
+		out []byte
+		err error
+	)
+
+	if out, err = io.ReadAll(b); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "you are executing a development version"
+	output := strings.TrimSpace(string(out))
+
+	if strings.Contains(output, expected) {
+		t.Errorf("bad warning under non-TTY: %s", output)
+	}
+
+	if hasWarnedDevelopmentVersion {
+		t.Error("bar warning under non-TTY")
+	}
+
+	if pty, tty, err := pty.Open(); err != nil {
+		t.Fatalf("failed creting PTY for testing: %v", err)
+	} else {
+		root.SetOut(tty)
+
+		defer pty.Close()
+		defer tty.Close()
+	}
+	version = DEV_VERSION
+	if err := root.Execute(); err != nil {
+		t.Errorf("unexpected error executing command; error: %v", err)
+	}
+
+	if !hasWarnedDevelopmentVersion {
+		t.Error("failed to warn about development version")
+	}
+
+	hasWarnedDevelopmentVersion = false
+	version = "100.100.100"
+	if err := root.Execute(); err != nil {
+		t.Errorf("unexpected error executing command; error: %v", err)
+	}
+
+	if hasWarnedDevelopmentVersion {
+		t.Error("should not have warned on non-dev version")
 	}
 }

--- a/cmd/shell/terminal_test.go
+++ b/cmd/shell/terminal_test.go
@@ -45,7 +45,7 @@ func TestPtyIsTerminal(t *testing.T) {
 
 	terminalChecker := NewTerminalChecker()
 
-	if !terminalChecker.IsTerminal(f, f) {
+	if !terminalChecker.IsTerminal(f) {
 		t.Error("expecting tty terminal on command")
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | #186  |
| -----: | :-----: |
| :trophy: Feature | Yes |
| :warning: Break Change | No |

**Description**

We have a new warning for every time you run `kool` in a development build. This should help prevent inadvertent usage of edge builds for Kool development team on other projects.

---

**Notes**

- The warning is only issued when output is a TTY (so we don't create hard to debug situations).
- The output is issues only once (even for recursive calls)
