### PR TITLE
Add kool deploy logs

### DIFF
--- a/cloud/k8s/kubectl.go
+++ b/cloud/k8s/kubectl.go
@@ -1,0 +1,92 @@
+package k8s
+
+import (
+	"errors"
+	"fmt"
+	"kool-dev/kool/api"
+	"kool-dev/kool/cmd/builder"
+	"kool-dev/kool/cmd/shell"
+	"os"
+	"path/filepath"
+)
+
+type K8S interface {
+	Authenticate(string, string) (err error)
+	Kubectl(shell.PathChecker) (builder.Command, error)
+	CloudService() string
+	Cleanup(shell.OutputWritter)
+}
+
+type DefaultK8S struct {
+	apiExec api.ExecCall
+	resp    *api.ExecResponse
+}
+
+var authTempPath = "/tmp"
+
+// NewDefaultK8S returns a new pointer for DefaultK8S with dependencies
+func NewDefaultK8S() *DefaultK8S {
+	return &DefaultK8S{
+		apiExec: api.NewDefaultExecCall(),
+	}
+}
+
+func (k *DefaultK8S) Authenticate(domain, service string) (err error) {
+	k.apiExec.Body().Set("domain", domain)
+	k.apiExec.Body().Set("service", service)
+
+	if k.resp, err = k.apiExec.Call(); err != nil {
+		return
+	}
+
+	if k.resp.Token == "" {
+		err = fmt.Errorf("failed to generate access credentials to cloud deploy")
+		return
+	}
+
+	err = os.WriteFile(k.getTempCAPath(), []byte(k.resp.CA), os.ModePerm)
+	return
+}
+
+func (k *DefaultK8S) Kubectl(looker shell.PathChecker) (kube builder.Command, err error) {
+	if k.resp == nil {
+		err = errors.New("calling kubectl but did not authenticate")
+		return
+	}
+
+	kube = builder.NewCommand("kubectl")
+
+	kube.AppendArgs("--server", k.resp.Server)
+	kube.AppendArgs("--token", k.resp.Token)
+	kube.AppendArgs("--namespace", k.resp.Namespace)
+	kube.AppendArgs("--certificate-authority", k.getTempCAPath())
+
+	if looker.LookPath(kube) != nil {
+		// we do not have 'kubectl' on current path... let's use a container!
+		kool := builder.NewCommand("kool")
+		kool.AppendArgs(
+			"docker", "--",
+			"-v", fmt.Sprintf("%s:%s", k.getTempCAPath(), k.getTempCAPath()),
+			"kooldev/toolkit:full",
+			kube.Cmd(),
+		)
+		kool.AppendArgs(kube.Args()...)
+		kube = kool
+	}
+
+	return
+}
+
+func (k *DefaultK8S) CloudService() string {
+	return k.resp.Path
+}
+
+func (k *DefaultK8S) Cleanup(out shell.OutputWritter) {
+	if err := os.Remove(k.getTempCAPath()); err != nil {
+		out.Warning("failed to clear up temporary file; error:", err.Error())
+	}
+}
+
+func (k *DefaultK8S) getTempCAPath() string {
+	return filepath.Join(authTempPath, ".kool-cluster-CA")
+}

--- a/cloud/k8s/kubectl_test.go
+++ b/cloud/k8s/kubectl_test.go
@@ -1,0 +1,171 @@
+package k8s
+
+import (
+	"errors"
+	"kool-dev/kool/api"
+	"kool-dev/kool/cmd/shell"
+	"os"
+	"strings"
+	"testing"
+)
+
+// fake api.ExecCall
+type fakeExecCall struct {
+	api.DefaultEndpoint
+
+	err  error
+	resp *api.ExecResponse
+}
+
+func (d *fakeExecCall) Call() (*api.ExecResponse, error) {
+	return d.resp, d.err
+}
+
+func newFakeExecCall() *fakeExecCall {
+	return &fakeExecCall{
+		DefaultEndpoint: *api.NewDefaultEndpoint(""),
+	}
+}
+
+// fake shell.OutputWritter
+type fakeOutputWritter struct {
+	warned []interface{}
+}
+
+func (*fakeOutputWritter) Println(args ...interface{}) {
+}
+
+func (*fakeOutputWritter) Printf(s string, args ...interface{}) {
+}
+
+func (f *fakeOutputWritter) Warning(args ...interface{}) {
+	f.warned = append(f.warned, args...)
+}
+
+func (*fakeOutputWritter) Success(args ...interface{}) {
+}
+
+func TestNewDefaultK8S(t *testing.T) {
+	k := NewDefaultK8S()
+	if _, ok := k.apiExec.(*api.DefaultExecCall); !ok {
+		t.Error("invalid type on apiExec")
+	}
+}
+
+func TestAuthenticate(t *testing.T) {
+	k := &DefaultK8S{
+		apiExec: newFakeExecCall(),
+	}
+
+	expectedErr := errors.New("call error")
+	k.apiExec.(*fakeExecCall).err = expectedErr
+
+	if err := k.Authenticate("foo", "bar"); !errors.Is(err, expectedErr) {
+		t.Error("unexpected error return from Authenticate")
+	}
+
+	k.apiExec.(*fakeExecCall).err = nil
+	k.apiExec.(*fakeExecCall).resp = &api.ExecResponse{
+		Server:    "server",
+		Namespace: "ns",
+		Path:      "path",
+		Token:     "",
+		CA:        "ca",
+	}
+
+	if err := k.Authenticate("foo", "bar"); !strings.Contains(err.Error(), "failed to generate access credentials") {
+		t.Errorf("unexpected error from DeployExec call: %v", err)
+	}
+
+	k.apiExec.(*fakeExecCall).resp.Token = "token"
+	authTempPath = t.TempDir()
+
+	if err := k.Authenticate("foo", "bar"); err != nil {
+		t.Errorf("unexpected error from Authenticate call: %v", err)
+	}
+}
+
+func TestCloudService(t *testing.T) {
+	k := &DefaultK8S{
+		apiExec: newFakeExecCall(),
+	}
+
+	k.apiExec.(*fakeExecCall).resp = &api.ExecResponse{
+		Path:  "path",
+		Token: "foo",
+	}
+
+	k.Authenticate("foo", "bar")
+
+	if k.CloudService() != "path" {
+		t.Errorf("unexpected CloudService return: %v", k.CloudService())
+	}
+}
+
+func TestTempCAPath(t *testing.T) {
+	k := NewDefaultK8S()
+
+	authTempPath = "fake-path"
+
+	if !strings.Contains(k.getTempCAPath(), authTempPath) {
+		t.Error("missing authTempPath from temp CA path")
+	}
+}
+
+func TestCleanup(t *testing.T) {
+	k := NewDefaultK8S()
+
+	authTempPath = t.TempDir()
+	if err := os.WriteFile(k.getTempCAPath(), []byte("ca"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeOut := &fakeOutputWritter{}
+
+	k.Cleanup(fakeOut)
+
+	if len(fakeOut.warned) != 0 {
+		t.Error("should not have warned on removing the file")
+	}
+
+	authTempPath = t.TempDir() + "test"
+	k.Cleanup(fakeOut)
+
+	if len(fakeOut.warned) != 2 {
+		t.Error("should have warned on removing the file once")
+	}
+}
+
+func TestKubectl(t *testing.T) {
+	authTempPath = t.TempDir()
+
+	k := &DefaultK8S{
+		apiExec: newFakeExecCall(),
+	}
+
+	k.apiExec.(*fakeExecCall).resp = &api.ExecResponse{
+		Server:    "server",
+		Namespace: "ns",
+		Path:      "path",
+		Token:     "token",
+		CA:        "ca",
+	}
+
+	fakeShell := &shell.FakeShell{}
+
+	if _, err := k.Kubectl(fakeShell); !strings.Contains(err.Error(), "but did not auth") {
+		t.Error("should get error before authenticating")
+	}
+
+	k.Authenticate("foo", "bar")
+
+	if cmd, _ := k.Kubectl(fakeShell); cmd.Cmd() != "kubectl" {
+		t.Error("should use kubectl")
+	}
+
+	fakeShell.MockLookPath = errors.New("err")
+
+	if cmd, _ := k.Kubectl(fakeShell); cmd.Cmd() != "kool" {
+		t.Error("should use kool")
+	}
+}

--- a/cloud/k8s/kubectl_test.go
+++ b/cloud/k8s/kubectl_test.go
@@ -60,7 +60,7 @@ func TestAuthenticate(t *testing.T) {
 	expectedErr := errors.New("call error")
 	k.apiExec.(*fakeExecCall).err = expectedErr
 
-	if err := k.Authenticate("foo", "bar"); !errors.Is(err, expectedErr) {
+	if _, err := k.Authenticate("foo", "bar"); !errors.Is(err, expectedErr) {
 		t.Error("unexpected error return from Authenticate")
 	}
 
@@ -73,32 +73,17 @@ func TestAuthenticate(t *testing.T) {
 		CA:        "ca",
 	}
 
-	if err := k.Authenticate("foo", "bar"); !strings.Contains(err.Error(), "failed to generate access credentials") {
+	if _, err := k.Authenticate("foo", "bar"); !strings.Contains(err.Error(), "failed to generate access credentials") {
 		t.Errorf("unexpected error from DeployExec call: %v", err)
 	}
 
 	k.apiExec.(*fakeExecCall).resp.Token = "token"
 	authTempPath = t.TempDir()
 
-	if err := k.Authenticate("foo", "bar"); err != nil {
+	if cloudService, err := k.Authenticate("foo", "bar"); err != nil {
 		t.Errorf("unexpected error from Authenticate call: %v", err)
-	}
-}
-
-func TestCloudService(t *testing.T) {
-	k := &DefaultK8S{
-		apiExec: newFakeExecCall(),
-	}
-
-	k.apiExec.(*fakeExecCall).resp = &api.ExecResponse{
-		Path:  "path",
-		Token: "foo",
-	}
-
-	k.Authenticate("foo", "bar")
-
-	if k.CloudService() != "path" {
-		t.Errorf("unexpected CloudService return: %v", k.CloudService())
+	} else if cloudService != "path" {
+		t.Errorf("unexpected cloudService return: %s", cloudService)
 	}
 }
 

--- a/cloud/k8s/kubectl_test.go
+++ b/cloud/k8s/kubectl_test.go
@@ -142,7 +142,7 @@ func TestKubectl(t *testing.T) {
 		t.Error("should get error before authenticating")
 	}
 
-	k.Authenticate("foo", "bar")
+	_, _ = k.Authenticate("foo", "bar")
 
 	if cmd, _ := k.Kubectl(fakeShell); cmd.Cmd() != "kubectl" {
 		t.Error("should use kubectl")

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -57,6 +57,7 @@ func AddKoolDeploy(root *cobra.Command) {
 	root.AddCommand(deployCmd)
 	deployCmd.AddCommand(NewDeployExecCommand(NewKoolDeployExec()))
 	deployCmd.AddCommand(NewDeployDestroyCommand(NewKoolDeployDestroy()))
+	deployCmd.AddCommand(NewDeployLogsCommand(NewKoolDeployLogs()))
 }
 
 // Execute runs the deploy logic.

--- a/cmd/deploy_exec.go
+++ b/cmd/deploy_exec.go
@@ -79,11 +79,13 @@ func (e *KoolDeployExec) Execute(args []string) (err error) {
 		return
 	}
 
+	// finish building exec command
 	kubectl.AppendArgs("exec", "-i")
 	if e.IsTerminal() {
 		kubectl.AppendArgs("-t")
 	}
-	kubectl.AppendArgs(e.cloud.CloudService(), "--")
+	kubectl.AppendArgs(e.cloud.CloudService(), "-c", "default")
+	kubectl.AppendArgs("--")
 	if len(args) == 0 {
 		args = []string{"bash"}
 	}

--- a/cmd/deploy_exec.go
+++ b/cmd/deploy_exec.go
@@ -13,8 +13,14 @@ import (
 // KoolDeployExec holds handlers and functions for using Deploy API
 type KoolDeployExec struct {
 	DefaultKoolService
+	Flags *KoolDeployExecFlags
 	env   environment.EnvStorage
 	cloud k8s.K8S
+}
+
+// KoolDeployExecFlags holds flags to kool deploy exec command
+type KoolDeployExecFlags struct {
+	Container string
 }
 
 // NewDeployExecCommand inits Cobra command for kool deploy exec
@@ -32,6 +38,7 @@ Must use a KOOL_API_TOKEN environment variable for authentication.`,
 	}
 
 	cmd.Flags().SetInterspersed(false)
+	cmd.Flags().StringVarP(&deployExec.Flags.Container, "container", "c", "default", "Container target.")
 	return
 }
 
@@ -39,6 +46,7 @@ Must use a KOOL_API_TOKEN environment variable for authentication.`,
 func NewKoolDeployExec() *KoolDeployExec {
 	return &KoolDeployExec{
 		*newDefaultKoolService(),
+		&KoolDeployExecFlags{"default"},
 		environment.NewEnvStorage(),
 		k8s.NewDefaultK8S(),
 	}
@@ -84,7 +92,7 @@ func (e *KoolDeployExec) Execute(args []string) (err error) {
 	if e.IsTerminal() {
 		kubectl.AppendArgs("-t")
 	}
-	kubectl.AppendArgs(cloudService, "-c", "default")
+	kubectl.AppendArgs(cloudService, "-c", e.Flags.Container)
 	kubectl.AppendArgs("--")
 	if len(args) == 0 {
 		args = []string{"bash"}

--- a/cmd/deploy_exec.go
+++ b/cmd/deploy_exec.go
@@ -47,8 +47,8 @@ func NewKoolDeployExec() *KoolDeployExec {
 // Execute runs the deploy exec logic - integrating with Deploy API
 func (e *KoolDeployExec) Execute(args []string) (err error) {
 	var (
-		domain  string
-		service string
+		domain, service, cloudService string
+
 		kubectl builder.Command
 	)
 
@@ -69,7 +69,7 @@ func (e *KoolDeployExec) Execute(args []string) (err error) {
 		return
 	}
 
-	if err = e.cloud.Authenticate(domain, service); err != nil {
+	if cloudService, err = e.cloud.Authenticate(domain, service); err != nil {
 		return
 	}
 
@@ -84,7 +84,7 @@ func (e *KoolDeployExec) Execute(args []string) (err error) {
 	if e.IsTerminal() {
 		kubectl.AppendArgs("-t")
 	}
-	kubectl.AppendArgs(e.cloud.CloudService(), "-c", "default")
+	kubectl.AppendArgs(cloudService, "-c", "default")
 	kubectl.AppendArgs("--")
 	if len(args) == 0 {
 		args = []string{"bash"}

--- a/cmd/deploy_exec.go
+++ b/cmd/deploy_exec.go
@@ -20,7 +20,7 @@ type KoolDeployExec struct {
 // NewDeployExecCommand inits Cobra command for kool deploy exec
 func NewDeployExecCommand(deployExec *KoolDeployExec) (cmd *cobra.Command) {
 	cmd = &cobra.Command{
-		Use:   "exec SERVICE COMMAND [--] [ARG...]",
+		Use:   "exec SERVICE [COMMAND] [--] [ARG...]",
 		Short: "Execute a command inside a running service container deployed to Kool Cloud",
 		Long: `After deploying an application to Kool Cloud using 'kool deploy',
 execute a COMMAND inside the specified SERVICE container (similar to an SSH session).

--- a/cmd/deploy_exec_test.go
+++ b/cmd/deploy_exec_test.go
@@ -13,6 +13,7 @@ import (
 func newFakeKoolDeployExec() *KoolDeployExec {
 	return &KoolDeployExec{
 		*newFakeKoolService(),
+		&KoolDeployExecFlags{},
 		environment.NewFakeEnvStorage(),
 		&fakeK8S{},
 	}
@@ -75,6 +76,7 @@ func TestKoolDeployExec(t *testing.T) {
 	mock.MockKubectlKube = fakeKubectl
 	fakeKubectl.MockInteractiveError = nil
 	e.term.(*shell.FakeTerminalChecker).MockIsTerminal = true
+	e.Flags.Container = "foo"
 
 	if err = e.Execute(args); err != nil {
 		t.Error("unexpected error")
@@ -82,7 +84,7 @@ func TestKoolDeployExec(t *testing.T) {
 
 	str := strings.Join(fakeKubectl.ArgsAppend, " ")
 
-	if !strings.Contains(str, "exec -i -t cloud-service -c default -- bash") {
+	if !strings.Contains(str, "exec -i -t cloud-service -c foo -- bash") {
 		t.Error("bad kubectl command args")
 	}
 }

--- a/cmd/deploy_exec_test.go
+++ b/cmd/deploy_exec_test.go
@@ -1,50 +1,27 @@
 package cmd
 
 import (
-	"errors"
-	"kool-dev/kool/api"
-	"kool-dev/kool/cmd/builder"
+	"kool-dev/kool/cloud/k8s"
 	"kool-dev/kool/environment"
 	"strings"
 	"testing"
 )
 
-type fakeExecCall struct {
-	api.DefaultEndpoint
-
-	err  error
-	resp *api.ExecResponse
-}
-
-func (d *fakeExecCall) Call() (*api.ExecResponse, error) {
-	return d.resp, d.err
-}
-
 func newFakeKoolDeployExec() *KoolDeployExec {
 	return &KoolDeployExec{
 		*newFakeKoolService(),
-		&builder.FakeCommand{}, // kubectl
-		&builder.FakeCommand{}, // kool
 		environment.NewFakeEnvStorage(),
-		&fakeExecCall{
-			DefaultEndpoint: *api.NewDefaultEndpoint(""),
-		},
+		nil,
 	}
 }
 
 func TestNewKoolDeployExec(t *testing.T) {
 	e := NewKoolDeployExec()
 
-	if _, ok := e.kubectl.(*builder.DefaultCommand); !ok {
-		t.Errorf("unexpected type for kubectl command")
-	}
-	if _, ok := e.kool.(*builder.DefaultCommand); !ok {
-		t.Errorf("unexpected type for kool command")
-	}
 	if _, ok := e.env.(*environment.DefaultEnvStorage); !ok {
 		t.Errorf("unexpected type for env storage")
 	}
-	if _, ok := e.apiExec.(*api.DefaultExecCall); !ok {
+	if _, ok := e.cloud.(*k8s.DefaultK8S); !ok {
 		t.Errorf("unexpected type for apiExec endpoint")
 	}
 }
@@ -64,58 +41,6 @@ func TestKoolDeployExec(t *testing.T) {
 		t.Errorf("expected: missing deploy domain; got something else")
 	}
 
-	var domain string = "example.com"
-	e.env.Set("KOOL_DEPLOY_DOMAIN", domain)
-
-	e.apiExec.(*fakeExecCall).err = errors.New("call error")
-
-	if err = e.Execute([]string{service}); !errors.Is(err, e.apiExec.(*fakeExecCall).err) {
-		t.Errorf("unexpected error from DeployExec call: %v", err)
-	}
-
-	e.apiExec.(*fakeExecCall).err = nil
-	e.apiExec.(*fakeExecCall).resp = &api.ExecResponse{
-		Server:    "server",
-		Namespace: "ns",
-		Path:      "path",
-		Token:     "",
-		CA:        "ca",
-	}
-
-	if err = e.Execute([]string{service}); !strings.Contains(err.Error(), "failed to generate access credentials") {
-		t.Errorf("unexpected error from DeployExec call: %v", err)
-	}
-
-	e.apiExec.(*fakeExecCall).resp.Token = "token"
-	authTempPath = t.TempDir()
-
-	if err = e.Execute([]string{service, "foo", "bar"}); err != nil {
-		t.Errorf("unexpected error from DeployExec call: %v", err)
-	}
-
-	args := e.kubectl.(*builder.FakeCommand).ArgsAppend
-	if args[1] != "server" || args[3] != "token" || args[5] != "ns" || !strings.Contains(args[7], ".kool-cluster-CA") {
-		t.Errorf("unexpected arguments to kubectl: %v", args)
-	}
-
-	if len(e.kool.(*builder.FakeCommand).ArgsAppend) > 0 {
-		t.Errorf("should not have used kool")
-	}
-
-	e.kubectl.(*builder.FakeCommand).MockLookPathError = errors.New("not found")
-	e.kubectl.(*builder.FakeCommand).MockCmd = "kub-foo"
-
-	if err = e.Execute([]string{service, "foo", "bar"}); err != nil {
-		t.Errorf("unexpected error from DeployExec call: %v", err)
-	}
-
-	args = e.kool.(*builder.FakeCommand).ArgsAppend
-
-	if len(args) == 0 {
-		t.Errorf("should have used kool")
-	}
-
-	if args[5] != "kub-foo" {
-		t.Errorf("unexpected kubectl Cmd on kool: %v", args)
-	}
+	// var domain string = "example.com"
+	// e.env.Set("KOOL_DEPLOY_DOMAIN", domain)
 }

--- a/cmd/deploy_logs.go
+++ b/cmd/deploy_logs.go
@@ -50,15 +50,10 @@ func NewKoolDeployLogs() *KoolDeployLogs {
 // Execute runs the deploy logs logic - integrating with API and K8S
 func (e *KoolDeployLogs) Execute(args []string) (err error) {
 	var (
-		domain  string
-		service string
+		domain, service, cloudService string
+
 		kubectl builder.Command
 	)
-
-	if len(args) == 0 {
-		err = fmt.Errorf("KoolDeployLogs.Execute: required at least one argument")
-		return
-	}
 
 	service = args[0]
 
@@ -71,7 +66,7 @@ func (e *KoolDeployLogs) Execute(args []string) (err error) {
 		return
 	}
 
-	if err = e.cloud.Authenticate(domain, service); err != nil {
+	if cloudService, err = e.cloud.Authenticate(domain, service); err != nil {
 		return
 	}
 
@@ -88,8 +83,7 @@ func (e *KoolDeployLogs) Execute(args []string) (err error) {
 	if e.Flags.Tail > 0 {
 		kubectl.AppendArgs("--tail", fmt.Sprintf("%d", e.Flags.Tail))
 	}
-	kubectl.AppendArgs(e.cloud.CloudService())
-	kubectl.AppendArgs("-c", "default")
+	kubectl.AppendArgs(cloudService, "-c", "default")
 
 	err = e.Interactive(kubectl)
 	return

--- a/cmd/deploy_logs.go
+++ b/cmd/deploy_logs.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+	"kool-dev/kool/api"
+	"kool-dev/kool/cloud/k8s"
+	"kool-dev/kool/cmd/builder"
+	"kool-dev/kool/environment"
+
+	"github.com/spf13/cobra"
+)
+
+// KoolDeployLogs holds handlers and functions for using Deploy API
+type KoolDeployLogs struct {
+	DefaultKoolService
+	Flags *KoolLogsFlags
+	env   environment.EnvStorage
+	cloud k8s.K8S
+}
+
+// NewDeployLogsCommand inits Cobra command for kool deploy logs
+func NewDeployLogsCommand(deployLogs *KoolDeployLogs) (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:   "logs [OPTIONS] SERVICE",
+		Short: "See the logs of running service container deployed to Kool Cloud",
+		Long: `After deploying an application to Kool Cloud using 'kool deploy',
+you can see the logs from the specified SERVICE container.
+Must use a KOOL_API_TOKEN environment variable for authentication.`,
+		Args: cobra.ExactArgs(1),
+		Run:  DefaultCommandRunFunction(deployLogs),
+
+		DisableFlagsInUseLine: true,
+	}
+
+	cmd.Flags().IntVarP(&deployLogs.Flags.Tail, "tail", "t", 25, "Number of lines to show from the end of the logs for each container. A value equal to 0 will show all lines.")
+	cmd.Flags().BoolVarP(&deployLogs.Flags.Follow, "follow", "f", false, "Follow log output.")
+	return
+}
+
+// NewKoolDeployLogs creates a new pointer with default KoolDeployLogs service dependencies
+func NewKoolDeployLogs() *KoolDeployLogs {
+	return &KoolDeployLogs{
+		*newDefaultKoolService(),
+		&KoolLogsFlags{25, false},
+		environment.NewEnvStorage(),
+		k8s.NewDefaultK8S(),
+	}
+}
+
+// Execute runs the deploy logs logic - integrating with API and K8S
+func (e *KoolDeployLogs) Execute(args []string) (err error) {
+	var (
+		domain  string
+		service string
+		kubectl builder.Command
+	)
+
+	if len(args) == 0 {
+		err = fmt.Errorf("KoolDeployLogs.Execute: required at least one argument")
+		return
+	}
+
+	service = args[0]
+
+	if url := e.env.Get("KOOL_API_URL"); url != "" {
+		api.SetBaseURL(url)
+	}
+
+	if domain = e.env.Get("KOOL_DEPLOY_DOMAIN"); domain == "" {
+		err = fmt.Errorf("missing deploy domain (env KOOL_DEPLOY_DOMAIN)")
+		return
+	}
+
+	if err = e.cloud.Authenticate(domain, service); err != nil {
+		return
+	}
+
+	defer e.cloud.Cleanup(e)
+
+	if kubectl, err = e.cloud.Kubectl(e); err != nil {
+		return
+	}
+
+	kubectl.AppendArgs("logs")
+	if e.Flags.Follow {
+		kubectl.AppendArgs("-f")
+	}
+	if e.Flags.Tail > 0 {
+		kubectl.AppendArgs("--tail", fmt.Sprintf("%d", e.Flags.Tail))
+	}
+	kubectl.AppendArgs(e.cloud.CloudService())
+	kubectl.AppendArgs("-c", "default")
+
+	err = e.Interactive(kubectl)
+	return
+}

--- a/cmd/deploy_logs_test.go
+++ b/cmd/deploy_logs_test.go
@@ -16,7 +16,7 @@ type fakeK8S struct {
 	CalledAuthenticateParamDomain  string
 	CalledAuthenticateParamService string
 	MockAuthenticateCloudService   string
-	MockAuthenticateError          error
+	MockAuthenticateErr            error
 
 	// Kubectl
 	CalledKubectl            bool
@@ -35,7 +35,7 @@ func (f *fakeK8S) Authenticate(domain, service string) (cloudService string, err
 	f.CalledAuthenticateParamService = service
 
 	cloudService = f.MockAuthenticateCloudService
-	err = f.MockAuthenticateError
+	err = f.MockAuthenticateErr
 	return
 }
 
@@ -105,13 +105,13 @@ func TestKoolDeployLogsExecute(t *testing.T) {
 
 	l.env.Set("KOOL_DEPLOY_DOMAIN", "deploy.domain")
 
-	l.cloud.(*fakeK8S).MockAuthenticateError = errors.New("authenticate error")
+	l.cloud.(*fakeK8S).MockAuthenticateErr = errors.New("authenticate error")
 
-	if err := l.Execute(args); !errors.Is(err, l.cloud.(*fakeK8S).MockAuthenticateError) {
+	if err := l.Execute(args); !errors.Is(err, l.cloud.(*fakeK8S).MockAuthenticateErr) {
 		t.Error("should get error on authenticate")
 	}
 
-	l.cloud.(*fakeK8S).MockAuthenticateError = nil
+	l.cloud.(*fakeK8S).MockAuthenticateErr = nil
 	l.cloud.(*fakeK8S).MockAuthenticateCloudService = "app"
 	l.cloud.(*fakeK8S).MockKubectlErr = errors.New("kubectl error")
 

--- a/cmd/deploy_logs_test.go
+++ b/cmd/deploy_logs_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"kool-dev/kool/cloud/k8s"
+	"kool-dev/kool/environment"
+	"strings"
+	"testing"
+)
+
+func fakeKoolDeployLogs() *KoolDeployLogs {
+	return &KoolDeployLogs{
+		*newFakeKoolService(),
+		&KoolLogsFlags{},
+		environment.NewFakeEnvStorage(),
+		nil,
+	}
+}
+
+func TestNewKoolDeployLogs(t *testing.T) {
+	l := NewKoolDeployLogs()
+
+	if l.Flags.Follow {
+		t.Error("unexpected default Follow behaviour")
+	}
+	if l.Flags.Tail != 25 {
+		t.Error("unexpected default Tail behaviour")
+	}
+	if _, ok := l.env.(*environment.DefaultEnvStorage); !ok {
+		t.Error("bad default type for env storage")
+	}
+	if _, ok := l.env.(*environment.DefaultEnvStorage); !ok {
+		t.Error("bad default type for env storage")
+	}
+	if _, ok := l.cloud.(*k8s.DefaultK8S); !ok {
+		t.Error("bad default type for k8s cloud")
+	}
+}
+
+func TestNewDeployLogsCommand(t *testing.T) {
+	cmd := NewDeployLogsCommand(fakeKoolDeployLogs())
+
+	if cmd.Flags().Lookup("tail") == nil {
+		t.Error("missing flag: tailt")
+	}
+
+	if cmd.Flags().Lookup("follow") == nil {
+		t.Error("missing flag: tailt")
+	}
+}
+
+func TestKoolDeployLogsExecute(t *testing.T) {
+	l := fakeKoolDeployLogs()
+	args := []string{"foo"}
+
+	l.env.Set("KOOL_API_URL", "api-url")
+
+	if err := l.Execute(args); !strings.Contains(err.Error(), "missing deploy domain") {
+		t.Error("should get error on missing domain")
+	}
+
+	// l.env.Set("KOOL_DEPLOY_DOMAIN", "deploy.domain")
+}

--- a/cmd/deploy_logs_test.go
+++ b/cmd/deploy_logs_test.go
@@ -55,7 +55,7 @@ func (f *fakeK8S) Cleanup(out shell.OutputWritter) {
 func fakeKoolDeployLogs() *KoolDeployLogs {
 	return &KoolDeployLogs{
 		*newFakeKoolService(),
-		&KoolLogsFlags{},
+		&KoolDeployLogsFlags{},
 		environment.NewFakeEnvStorage(),
 		&fakeK8S{},
 	}

--- a/cmd/shell/fake_shell.go
+++ b/cmd/shell/fake_shell.go
@@ -31,6 +31,7 @@ type FakeShell struct {
 	MockOutStream io.Writer
 	MockErrStream io.Writer
 	MockInStream  io.Reader
+	MockLookPath  error
 }
 
 // InStream is a mocked testing function
@@ -111,7 +112,10 @@ func (f *FakeShell) LookPath(command builder.Command) (err error) {
 
 	if _, ok := command.(*builder.FakeCommand); ok {
 		err = command.(*builder.FakeCommand).MockLookPathError
+		return
 	}
+
+	err = f.MockLookPath
 
 	return
 }

--- a/cmd/shell/fake_shell_test.go
+++ b/cmd/shell/fake_shell_test.go
@@ -79,6 +79,15 @@ func TestFakeShell(t *testing.T) {
 		t.Error("failed to use mocked LookPath function on FakeShell")
 	}
 
+	if val, ok := f.CalledLookPath["cmd"]; !val || !ok || lookPathError != command.MockLookPathError {
+		t.Error("failed to use mocked LookPath function on FakeShell")
+	}
+
+	f.MockLookPath = errors.New("mock look path err")
+	if err := f.LookPath(builder.NewCommand("")); !errors.Is(err, f.MockLookPath) {
+		t.Error("failed returning MockLookPath")
+	}
+
 	f.Println()
 
 	if !f.CalledPrintln {

--- a/cmd/shell/shell.go
+++ b/cmd/shell/shell.go
@@ -37,8 +37,22 @@ type DefaultShell struct {
 	env       environment.EnvStorage
 }
 
+// OutputWritter implements basic output for CLIss
+type OutputWritter interface {
+	Println(...interface{})
+	Printf(string, ...interface{})
+	Warning(...interface{})
+	Success(...interface{})
+}
+
+type PathChecker interface {
+	LookPath(builder.Command) error
+}
+
 // Shell implements functions for handling a shell
 type Shell interface {
+	OutputWritter
+	PathChecker
 	InStream() io.Reader
 	SetInStream(io.Reader)
 	OutStream() io.Writer
@@ -47,12 +61,7 @@ type Shell interface {
 	SetErrStream(io.Writer)
 	Exec(builder.Command, ...string) (string, error)
 	Interactive(builder.Command, ...string) error
-	LookPath(builder.Command) error
-	Println(...interface{})
-	Printf(string, ...interface{})
 	Error(error)
-	Warning(...interface{})
-	Success(...interface{})
 }
 
 // NewShell creates a new shell


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | #300  |
| -----: | :-----: |
| :trophy: Feature | Yes |
| :pencil: Refactor | Yes |
| :open_book: Documentation | No |
| :warning: Break Change | No |

**Description**

This PR introduces `kool deploy logs` which will fetch logs straight from Kool Cloud Kubernetes cluster for a specific deployment and display or tail it on the screen.

---

**Notes**

This adds a new package `cloud/k8s`. The namespace `cloud` should be used in a larger reorganization to take place in a next PR.
Test coverage for this feature and refactoring will still be improved.
