### PR TITLE
fix docker-compose container version TTY carring over

### DIFF
--- a/cmd/compose/docker-compose.go
+++ b/cmd/compose/docker-compose.go
@@ -12,6 +12,11 @@ import (
 // DockerComposeImage holds the Docker image:tag to use for Docker Compose
 const DockerComposeImage = "docker/compose:1.28.0"
 
+// TtyAware interface holds functions for becoming aware of TTY
+type TtyAware interface {
+	SetIsTTY(bool)
+}
+
 // DockerCompose holds data and logic to wrap docker-compose command
 // within a container for flexibility
 type DockerCompose struct {
@@ -33,10 +38,8 @@ func NewDockerCompose(cmd string, args ...string) *DockerCompose {
 }
 
 // SetIsTTY sets whether we are under TTY
-func (c *DockerCompose) SetIsTTY(tty bool) *DockerCompose {
+func (c *DockerCompose) SetIsTTY(tty bool) {
 	c.isTTY = tty
-
-	return c
 }
 
 // SetShell sets the shell.Shell to be used
@@ -117,6 +120,8 @@ func (c *DockerCompose) String() string {
 }
 
 // Copy clones the pointer to avoid unintended modifications
-func (c *DockerCompose) Copy() builder.Command {
-	return NewDockerCompose(c.Command.Cmd(), c.Command.Args()...)
+func (c *DockerCompose) Copy() (copied builder.Command) {
+	copied = NewDockerCompose(c.Command.Cmd(), c.Command.Args()...)
+	copied.(*DockerCompose).SetIsTTY(c.isTTY)
+	return
 }

--- a/cmd/compose/docker-compose_test.go
+++ b/cmd/compose/docker-compose_test.go
@@ -100,7 +100,13 @@ func TestDockerComposeArgsParsing(t *testing.T) {
 		t.Error("unexpected Cmd() return")
 	}
 
-	if cp, ok := dc.Copy().(*DockerCompose); !ok || cp == nil || cp.Command.Cmd() != dc.Command.Cmd() || len(cp.Command.Args()) != len(dc.Command.Args()) {
+	if cp, ok := dc.Copy().(*DockerCompose); !ok || cp == nil || cp.isTTY != dc.isTTY || cp.Command.Cmd() != dc.Command.Cmd() || len(cp.Command.Args()) != len(dc.Command.Args()) {
 		t.Error("bad copy")
+	}
+
+	dc.SetIsTTY(true)
+
+	if cp, ok := dc.Copy().(*DockerCompose); !ok || cp == nil || !cp.isTTY {
+		t.Error("bad copy - failed passing isTTY")
 	}
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -62,9 +62,9 @@ func (e *KoolExec) Execute(args []string) (err error) {
 		e.composeExec.AppendArgs("-T")
 	}
 
-	if _, assert := e.composeExec.(*compose.DockerCompose); assert {
+	if aware, ok := e.composeExec.(compose.TtyAware); ok {
 		// let DockerCompose know about whether we are under TTY or not
-		e.composeExec.(*compose.DockerCompose).SetIsTTY(e.IsTerminal())
+		aware.SetIsTTY(e.IsTerminal())
 	}
 
 	if len(e.Flags.EnvVariables) > 0 {


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | https://github.com/kool-dev/kool/issues/319 |
| -----: | :-----: |
| :beetle: Bug Fix | Yes |
| :warning: Break Change | No |

**Description**

Fixes carrying over TTY awareness for docker-compose command when using container strategy.
