### PR TITLE
WordPress Doc Update

### DIFF
--- a/cmd/presets/configs.go
+++ b/cmd/presets/configs.go
@@ -301,14 +301,14 @@ questions:
   compose:
     - key: app
       default_answer: PHP 8.0
-      message: What app service do you want to use
+      message: What PHP version do you want to use
       options:
-        - name: PHP 7.4
-          template: wordpress74.yml
         - name: PHP 8.0
           template: wordpress80.yml
+        - name: PHP 7.4
+          template: wordpress74.yml
     - key: database
-      default_answer: MySQL 5.7
+      default_answer: MySQL 8.0
       message: What database service do you want to use
       options:
         - name: MySQL 8.0

--- a/docs/2-Presets/WordPress.md
+++ b/docs/2-Presets/WordPress.md
@@ -116,8 +116,6 @@ app_1       | time="2021-05-01T21:02:06Z" level=info msg="success to start progr
 
 ## 3. Update Database Information
 
-> IMPORTANT: if you're on **Windows WSL** or **Linux**, you need to run `sudo chown your-user:your-user -R ./` inside your new project directory to change the owner and group of all the WordPress files to your current user.
-
 You should now be able to access your new WordPress installation at [http://localhost](http://localhost) and see the WordPress welcome page (or, right after you select your language). Hooray!
 
 In order to get started, WordPress will ask you for some information about the database. Use the following default values to match the settings in your auto-generated **docker-compose.yml** file.


### PR DESCRIPTION
| Issue | # |
| -----: | :-----: |
| :open_book: Documentation | Yes |

**Description**

Since the WordPress images have been updated to fix user permission issues, we can remove a temporary note for Windows WSL and Linux users.

Also updated the `configs.go` preset file after parsing presets.