### PR TITLE
Add flag --foreground to kool start

### DIFF
--- a/commands/kool_upgrade_available_checker_test.go
+++ b/commands/kool_upgrade_available_checker_test.go
@@ -1,11 +1,7 @@
 package commands
 
 import (
-	"kool-dev/kool/core/builder"
-	"kool-dev/kool/core/environment"
-	"kool-dev/kool/core/network"
 	"kool-dev/kool/core/shell"
-	"kool-dev/kool/services/checker"
 	"kool-dev/kool/services/updater"
 
 	"errors"
@@ -21,13 +17,7 @@ func newFakeUpdateAwareService(start *KoolStart, koolFakeUpdater *updater.FakeUp
 }
 
 func TestStartWithUpdaterWrapper(t *testing.T) {
-	koolStart := &KoolStart{
-		*newFakeKoolService(),
-		&checker.FakeChecker{},
-		&network.FakeHandler{},
-		environment.NewFakeEnvStorage(),
-		&builder.FakeCommand{MockCmd: "start"},
-	}
+	koolStart := newMockStart()
 
 	koolUpdater := &updater.FakeUpdater{
 		MockCurrentVersion: "0.0.0",
@@ -60,13 +50,7 @@ func TestStartWithUpdaterWrapper(t *testing.T) {
 }
 
 func TestStartWithUpdaterWrapperError(t *testing.T) {
-	koolStart := &KoolStart{
-		*newFakeKoolService(),
-		&checker.FakeChecker{},
-		&network.FakeHandler{},
-		environment.NewFakeEnvStorage(),
-		&builder.FakeCommand{MockCmd: "start"},
-	}
+	koolStart := newMockStart()
 
 	koolUpdater := &updater.FakeUpdater{
 		MockCurrentVersion: "0.0.0",
@@ -97,13 +81,7 @@ func TestStartWithUpdaterWrapperError(t *testing.T) {
 }
 
 func TestStartWithUpdaterWrapperSameVersion(t *testing.T) {
-	koolStart := &KoolStart{
-		*newFakeKoolService(),
-		&checker.FakeChecker{},
-		&network.FakeHandler{},
-		environment.NewFakeEnvStorage(),
-		&builder.FakeCommand{MockCmd: "start"},
-	}
+	koolStart := newMockStart()
 
 	koolUpdater := &updater.FakeUpdater{
 		MockCurrentVersion: "1.0.0",
@@ -134,13 +112,7 @@ func TestStartWithUpdaterWrapperSameVersion(t *testing.T) {
 }
 
 func TestDontCheckForUpdatesWhenNonTerminal(t *testing.T) {
-	koolStart := &KoolStart{
-		*newFakeKoolService(),
-		&checker.FakeChecker{},
-		&network.FakeHandler{},
-		environment.NewFakeEnvStorage(),
-		&builder.FakeCommand{MockCmd: "start"},
-	}
+	koolStart := newMockStart()
 
 	koolUpdater := &updater.FakeUpdater{
 		MockCurrentVersion: "0.0.0",

--- a/docs/4-Commands/kool-start.md
+++ b/docs/4-Commands/kool-start.md
@@ -14,7 +14,8 @@ kool start [SERVICE...]
 ### Options
 
 ```
-  -h, --help   help for start
+  -f, --foreground   Start containers in foreground mode
+  -h, --help         help for start
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | https://github.com/kool-dev/kool/issues/61 |
| -----: | :-----: |
| :trophy: Feature | Yes |
| :open_book: Documentation | No |
| :warning: Break Change | No |

**Description**

This adds in a new flag to `kool start`, the `--foreground`, which can be used for having avoiding to spawn the containers in detached mode (default behavior on `kool start`).
