### PR TITLE
Add MariaDB as database option for Laravel and Symfony

### DIFF
--- a/core/presets/configs.go
+++ b/core/presets/configs.go
@@ -90,6 +90,8 @@ questions:
           template: mysql8.yml
         - name: MySQL 5.7
           template: mysql57.yml
+        - name: MariaDB 10.5
+          template: mariadb105.yml
         - name: PostgreSQL 13.0
           template: postgresql13.yml
         - name: none
@@ -258,6 +260,8 @@ questions:
           template: mysql8.yml
         - name: MySQL 5.7
           template: mysql57.yml
+        - name: MariaDB 10.5
+          template: mariadb105.yml
         - name: PostgreSQL 13.0
           template: postgresql13.yml
         - name: none

--- a/core/presets/templates.go
+++ b/core/presets/templates.go
@@ -120,6 +120,30 @@ volumes:
 `,
 	}
 	templates["database"] = map[string]string{
+		"mariadb105.yml": `services:
+  database:
+    image: mariadb:10.5
+    ports:
+    - ${KOOL_DATABASE_PORT:-3306}:3306
+    environment:
+      MARIADB_ROOT_PASSWORD: ${DB_PASSWORD-rootpass}
+      MARIADB_DATABASE: ${DB_DATABASE-database}
+      MARIADB_USER: ${DB_USERNAME-user}
+      MARIADB_PASSWORD: ${DB_PASSWORD-pass}
+      MARIADB_ALLOW_EMPTY_PASSWORD: "yes"
+    volumes:
+    - database:/var/lib/mysql:delegated
+    networks:
+    - kool_local
+    healthcheck:
+      test: mysqladmin -p${DB_PASSWORD-pass} ping
+
+volumes:
+  database:
+
+scripts:
+  maria: kool exec -e MYSQL_PWD=$DB_PASSWORD database mariadb -u $DB_USERNAME $DB_DATABASE
+`,
 		"mysql57-adonis.yml": `services:
   database:
     image: mysql:5.7

--- a/docs/2-Presets/Laravel.md
+++ b/docs/2-Presets/Laravel.md
@@ -40,6 +40,7 @@ $ Preset laravel is initializing!
 ? What database service do you want to use [Use arrows to move, type to filter]
 > MySQL 8.0
   MySQL 5.7
+  MariaDB 10.5
   PostgreSQL 13.0
   none
 
@@ -80,7 +81,7 @@ You need to update some default values in Laravel's **.env.example** file to mat
 
 ### Database Services
 
-MySQL 5.7 and 8.0
+MySQL 5.7 and 8.0 or MariaDB 10.5
 
 ```diff
 -DB_HOST=127.0.0.1

--- a/docs/2-Presets/Symfony.md
+++ b/docs/2-Presets/Symfony.md
@@ -40,6 +40,7 @@ $ Preset symfony is initializing!
 ? What database service do you want to use [Use arrows to move, type to filter]
 > MySQL 8.0
   MySQL 5.7
+  MariaDB 10.5
   PostgreSQL 13.0
   none
 
@@ -96,6 +97,10 @@ MySQL 5.7 and 8.0
 +DATABASE_URL="mysql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_DATABASE}?serverVersion=${DB_VERSION}"
 +# DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
 ```
+
+MariaDB 10.5
+
+It's the same as Mysql, except for the `serverVersion` value. Please refer to [Doctrine DBAL configuration docs](https://symfony.com/doc/current/reference/configuration/doctrine.html#doctrine-dbal-configuration) to set the correct `DB_VERSION` value.
 
 PostgreSQL 13.0
 

--- a/presets/laravel/preset-config.yml
+++ b/presets/laravel/preset-config.yml
@@ -20,6 +20,8 @@ questions:
           template: mysql8.yml
         - name: MySQL 5.7
           template: mysql57.yml
+        - name: MariaDB 10.5
+          template: mariadb105.yml
         - name: PostgreSQL 13.0
           template: postgresql13.yml
         - name: none

--- a/presets/symfony/preset-config.yml
+++ b/presets/symfony/preset-config.yml
@@ -20,6 +20,8 @@ questions:
           template: mysql8.yml
         - name: MySQL 5.7
           template: mysql57.yml
+        - name: MariaDB 10.5
+          template: mariadb105.yml
         - name: PostgreSQL 13.0
           template: postgresql13.yml
         - name: none

--- a/templates/database/mariadb105.yml
+++ b/templates/database/mariadb105.yml
@@ -1,0 +1,23 @@
+services:
+  database:
+    image: mariadb:10.5
+    ports:
+    - ${KOOL_DATABASE_PORT:-3306}:3306
+    environment:
+      MARIADB_ROOT_PASSWORD: ${DB_PASSWORD-rootpass}
+      MARIADB_DATABASE: ${DB_DATABASE-database}
+      MARIADB_USER: ${DB_USERNAME-user}
+      MARIADB_PASSWORD: ${DB_PASSWORD-pass}
+      MARIADB_ALLOW_EMPTY_PASSWORD: "yes"
+    volumes:
+    - database:/var/lib/mysql:delegated
+    networks:
+    - kool_local
+    healthcheck:
+      test: mysqladmin -p${DB_PASSWORD-pass} ping
+
+volumes:
+  database:
+
+scripts:
+  maria: kool exec -e MYSQL_PWD=$DB_PASSWORD database mariadb -u $DB_USERNAME $DB_DATABASE


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | - |
| -----: | :-----: |
| :trophy: Feature | Yes |
| :open_book: Documentation | Yes |
| :warning: Break Change | No |

**Description**

Adding a new option for `MariaDB 10.5` as database to be used on Laravel and Symfony apps on the `kool preset` command (thus also available at `kool create`).

