### PR TITLE
feature(restart): add purge flag to restart command

### DIFF
--- a/commands/restart.go
+++ b/commands/restart.go
@@ -4,15 +4,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// KoolRestartFlags holds the flags for the kool restart command
+type KoolRestartFlags struct {
+	Purge bool
+}
+
+var flags *KoolRestartFlags = &KoolRestartFlags{false}
+
 // NewRestartCommand initializes new kool start command
-func NewRestartCommand(stop KoolService, start KoolService) *cobra.Command {
-	return &cobra.Command{
+func NewRestartCommand(stop KoolService, start KoolService) (restartCmd *cobra.Command) {
+	restartCmd = &cobra.Command{
 		Use:   "restart",
 		Short: "Restart running service containers (the same as 'kool stop' followed by 'kool start')",
-		Run:   DefaultCommandRunFunction(stop, start),
+		Run: func(cmd *cobra.Command, args []string) {
+			if _, ok := stop.(*KoolStop); ok && flags.Purge {
+				stop.(*KoolStop).Flags.Purge = true
+			}
+			DefaultCommandRunFunction(stop, start)(cmd, args)
+		},
 
 		DisableFlagsInUseLine: true,
 	}
+
+	restartCmd.Flags().BoolVarP(&flags.Purge, "purge", "", false, "Remove all persistent data from volume mounts on containers")
+
+	return
 }
 
 func AddKoolRestart(root *cobra.Command) {

--- a/commands/restart_test.go
+++ b/commands/restart_test.go
@@ -66,3 +66,19 @@ func TestFailingStopRestartCommand(t *testing.T) {
 		t.Error("did not call Error due to error on start service")
 	}
 }
+
+func TestPurgeRestartCommand(t *testing.T) {
+	fakeStop := newFakeKoolStop()
+	fakeStart := &FakeKoolService{}
+
+	cmd := NewRestartCommand(fakeStop, fakeStart)
+	cmd.SetArgs([]string{"--purge"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("unexpected error executing restart command; error: %v", err)
+	}
+
+	if !fakeStop.Flags.Purge {
+		t.Error("did not set the purge flag to true in the stop service")
+	}
+}

--- a/docs/4-Commands/kool-restart.md
+++ b/docs/4-Commands/kool-restart.md
@@ -9,7 +9,8 @@ kool restart
 ### Options
 
 ```
-  -h, --help   help for restart
+  -h, --help    help for restart
+      --purge   Remove all persistent data from volume mounts on containers
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | #313 |
| -----: | :-----: |
| :beetle: Bug Fix | No |
| :trophy: Feature | Yes |
| :pencil: Refactor | No |
| :open_book: Documentation | No |
| :warning: Break Change | No |

**Description**


This PR adds the `--purge` flag to the `restart`, forwarding its value to the stop service used by the command.

----