### PR TITLE
Clean Up Docker Images Section of Docs

### DIFF
--- a/docs/3-Docker-Images/1-Introduction.md
+++ b/docs/3-Docker-Images/1-Introduction.md
@@ -1,0 +1,18 @@
+When you start developing in containers, you quickly realize the official Docker images are built for deployment, and not for the special considerations (and nuances) of local development. One of the most common and recurring problems we see are permission issues with mapped volumes, due to host users being different from container users. Kool fixes this problem, and many others, by creating custom Docker images optimized for local development environments.
+
+A few of the optimizations included in Kool's Docker images:
+- UID mapping to host user to solve permission issues
+- Alpine base images to remain small and up-to-date
+- Configured with sane defaults - for development as well as production
+- Environment variables to easily update the most common settings
+- Battle-tested - Firework has been using these images in production for quite a long time now!
+
+## Kool-Optimized Docker Images
+
+- PHP images: https://github.com/kool-dev/docker-php
+- Nginx images: https://github.com/kool-dev/docker-nginx
+- Node images: https://github.com/kool-dev/docker-node
+- Java images: https://github.com/kool-dev/docker-java
+- DevOps images: https://github.com/kool-dev/docker-toolkit
+
+> Disclaimer: Kool Docker images follow our recommended best practices, which are aimed at making your life easier. However, you can use the **Kool CLI** with any Docker images you like - assuming you know what you're doing :).

--- a/docs/3-Docker-Images/1-kooldev--php.md
+++ b/docs/3-Docker-Images/1-kooldev--php.md
@@ -1,1 +1,0 @@
-Coming soon

--- a/docs/3-Docker-Images/2-kooldev--node.md
+++ b/docs/3-Docker-Images/2-kooldev--node.md
@@ -1,1 +1,0 @@
-Coming soon

--- a/docs/3-Docker-Images/3-kooldev--nginx.md
+++ b/docs/3-Docker-Images/3-kooldev--nginx.md
@@ -1,1 +1,0 @@
-Coming soon

--- a/docs/3-Docker-Images/4-kooldev--kool.md
+++ b/docs/3-Docker-Images/4-kooldev--kool.md
@@ -1,1 +1,0 @@
-Coming soon

--- a/docs/5-Snippets/Generate-PDFs.md
+++ b/docs/5-Snippets/Generate-PDFs.md
@@ -1,0 +1,101 @@
+# Generate PDFs
+
+Easily add a `pdf` service container to your project that generates PDFs from any URL or HTML content.
+
+## docker-compose.yml
+
+```yaml
+pdf:
+  image: "kooldev/pdf:latest"
+  expose:
+    - 3000
+  networks:
+    - kool_local
+```
+
+### Full Example
+
+```diff
+version: "3.7"
+services:
+  app:
+    image: kooldev/php:8.0-nginx
+    ports:
+      - ${KOOL_APP_PORT:-80}:80
+    environment:
+      ASUSER: ${KOOL_ASUSER:-0}
+      UID: ${UID:-0}
+    volumes:
+      - .:/app:delegated
+    networks:
+      - kool_local
+      - kool_global
+  database:
+    image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
+    ports:
+      - ${KOOL_DATABASE_PORT:-3306}:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD-rootpass}
+      MYSQL_DATABASE: ${DB_DATABASE-database}
+      MYSQL_USER: ${DB_USERNAME-user}
+      MYSQL_PASSWORD: ${DB_PASSWORD-pass}
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    volumes:
+      - database:/var/lib/mysql:delegated
+    networks:
+      - kool_local
+    healthcheck:
+      test:
+        - CMD
+        - mysqladmin
+        - ping
++  pdf:
++    image: "kooldev/pdf:latest"
++    expose:
++      - 3000
++    networks:
++      - kool_local
+volumes:
+  database: null
+networks:
+  kool_local: null
+  kool_global:
+    external: true
+    name: ${KOOL_GLOBAL_NETWORK:-kool_global}
+```
+
+## Usage
+
+### From a URL:
+
+Returns a rendered PDF from the provided URL (or JSON response with an error message and status).
+
+Endpoint:
+- `GET /from-url?url=`
+
+Parameters:
+- `url`: URL of the page you want to convert to a PDF
+
+### From HTML content:
+
+```
+use GuzzleHttp\Client;
+
+// `pdf` is the docker-compose service name
+$pdf = (new Client())->post('http://pdf:3000/from-html', [
+    'form_params' => [
+        'html' => '<h1>This is my super kool HTML that I want to turn into an awesome PDF file!</h1><p>You get the idea of how this works <strong>:)</strong></p>',
+        'options' => json_encode([
+            'format' => 'A4',
+            'printBackground' => false,
+        ]),
+    ],
+])->getBody();
+
+file_put_contents('path/to/my/super-kool.pdf', $pdf);
+```
+
+---
+
+Read more at [https://github.com/kool-dev/pdf](https://github.com/kool-dev/pdf).

--- a/docs/5-Snippets/Mailhog.md
+++ b/docs/5-Snippets/Mailhog.md
@@ -84,8 +84,8 @@ services:
 +   image: mailhog/mailhog:latest
 +   environment:
 +     - MH_STORAGE=maildir
-+   volumes:
-+     - mailhog:/maildir:delegated
++   # volumes:
++   #   - mailhog:/maildir:delegated
 +   ports:
 +     - "8025:8025"
 +   networks:


### PR DESCRIPTION
| Issue | # |
| -----: | :-----: |
| :open_book: Documentation | Yes |

**Description**

- add new Introduction page to Docker Images, which re-uses some of the content from Fabricio's blog post - specifically, the "Tailored Docker Images" section (see https://blog.kool.dev/article/using-docker-for-local-development/)
- remove "Coming Soon" pages under Docker Images

**Notes**

This PR also includes file changes from previously opened PR https://github.com/kool-dev/kool/pull/345