### PR TITLE
Add --rebuild to run docker-compose pull/build on kool start/restart

### DIFF
--- a/commands/kool_upgrade_available_checker_test.go
+++ b/commands/kool_upgrade_available_checker_test.go
@@ -17,7 +17,7 @@ func newFakeUpdateAwareService(start *KoolStart, koolFakeUpdater *updater.FakeUp
 }
 
 func TestStartWithUpdaterWrapper(t *testing.T) {
-	koolStart := newMockStart()
+	koolStart := newFakeKoolStart()
 
 	koolUpdater := &updater.FakeUpdater{
 		MockCurrentVersion: "0.0.0",
@@ -50,7 +50,7 @@ func TestStartWithUpdaterWrapper(t *testing.T) {
 }
 
 func TestStartWithUpdaterWrapperError(t *testing.T) {
-	koolStart := newMockStart()
+	koolStart := newFakeKoolStart()
 
 	koolUpdater := &updater.FakeUpdater{
 		MockCurrentVersion: "0.0.0",
@@ -81,7 +81,7 @@ func TestStartWithUpdaterWrapperError(t *testing.T) {
 }
 
 func TestStartWithUpdaterWrapperSameVersion(t *testing.T) {
-	koolStart := newMockStart()
+	koolStart := newFakeKoolStart()
 
 	koolUpdater := &updater.FakeUpdater{
 		MockCurrentVersion: "1.0.0",
@@ -112,7 +112,7 @@ func TestStartWithUpdaterWrapperSameVersion(t *testing.T) {
 }
 
 func TestDontCheckForUpdatesWhenNonTerminal(t *testing.T) {
-	koolStart := newMockStart()
+	koolStart := newFakeKoolStart()
 
 	koolUpdater := &updater.FakeUpdater{
 		MockCurrentVersion: "0.0.0",

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -6,19 +6,23 @@ import (
 
 // KoolRestartFlags holds the flags for the kool restart command
 type KoolRestartFlags struct {
-	Purge bool
+	Purge   bool
+	Rebuild bool
 }
-
-var flags *KoolRestartFlags = &KoolRestartFlags{false}
 
 // NewRestartCommand initializes new kool start command
 func NewRestartCommand(stop KoolService, start KoolService) (restartCmd *cobra.Command) {
+	var flags *KoolRestartFlags = &KoolRestartFlags{false, false}
+
 	restartCmd = &cobra.Command{
 		Use:   "restart",
 		Short: "Restart running service containers (the same as 'kool stop' followed by 'kool start')",
 		Run: func(cmd *cobra.Command, args []string) {
 			if _, ok := stop.(*KoolStop); ok && flags.Purge {
 				stop.(*KoolStop).Flags.Purge = true
+			}
+			if _, ok := start.(*KoolStart); ok && flags.Rebuild {
+				start.(*KoolStart).Flags.Rebuild = true
 			}
 			DefaultCommandRunFunction(stop, start)(cmd, args)
 		},
@@ -27,6 +31,7 @@ func NewRestartCommand(stop KoolService, start KoolService) (restartCmd *cobra.C
 	}
 
 	restartCmd.Flags().BoolVarP(&flags.Purge, "purge", "", false, "Remove all persistent data from volume mounts on containers")
+	restartCmd.Flags().BoolVarP(&flags.Rebuild, "rebuild", "", false, "Updates and builds service's images")
 
 	return
 }

--- a/commands/restart_test.go
+++ b/commands/restart_test.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"errors"
+	"io"
+	"kool-dev/kool/core/shell"
 	"testing"
 )
 
@@ -80,5 +82,23 @@ func TestPurgeRestartCommand(t *testing.T) {
 
 	if !fakeStop.Flags.Purge {
 		t.Error("did not set the purge flag to true in the stop service")
+	}
+}
+
+func TestRebuildRestartCommand(t *testing.T) {
+	fakeStop := &FakeKoolService{}
+	fakeStart := newFakeKoolStart()
+
+	cmd := NewRestartCommand(fakeStop, fakeStart)
+	cmd.SetArgs([]string{"--rebuild"})
+
+	fakeStart.rebuilder.(*KoolRebuild).shell.(*shell.FakeShell).MockOutStream = io.Discard
+
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("unexpected error executing restart command; error: %v", err)
+	}
+
+	if !fakeStart.Flags.Rebuild {
+		t.Error("did not set the rebuild flag to true in the start service")
 	}
 }

--- a/commands/start.go
+++ b/commands/start.go
@@ -109,7 +109,7 @@ func (s *KoolStart) Execute(args []string) (err error) {
 }
 
 func (s *KoolStart) rebuild() (err error) {
-	var task = NewKoolTask("Pulling and building service's images", s.rebuilder)
+	var task = NewKoolTask("Updating service's images", s.rebuilder)
 
 	task.SetInStream(s.InStream())
 	task.SetOutStream(s.OutStream())

--- a/commands/start_test.go
+++ b/commands/start_test.go
@@ -106,6 +106,19 @@ func TestStartRebuildFlag(t *testing.T) {
 	if !rebuilder.pull.(*builder.FakeCommand).CalledCmd || !rebuilder.build.(*builder.FakeCommand).CalledCmd {
 		t.Error("should have executed pull and build")
 	}
+
+	rebuilder.pull.(*builder.FakeCommand).MockInteractiveError = errors.New("mock pull error")
+
+	if err := rebuilder.Execute(nil); !errors.Is(err, rebuilder.pull.(*builder.FakeCommand).MockInteractiveError) {
+		t.Error("expected pull error")
+	}
+
+	rebuilder.pull.(*builder.FakeCommand).MockInteractiveError = nil
+	rebuilder.build.(*builder.FakeCommand).MockInteractiveError = errors.New("mock build error")
+
+	if err := rebuilder.Execute(nil); !errors.Is(err, rebuilder.build.(*builder.FakeCommand).MockInteractiveError) {
+		t.Error("expected build error")
+	}
 }
 
 func TestStartServicesCommand(t *testing.T) {

--- a/commands/start_test.go
+++ b/commands/start_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newMockStart() *KoolStart {
+func newFakeKoolStart() *KoolStart {
 	return &KoolStart{
 		*newFakeKoolService(),
 		&KoolStartFlags{},
@@ -32,7 +32,7 @@ func newMockStart() *KoolStart {
 }
 
 func TestStartAllCommand(t *testing.T) {
-	koolStart := newMockStart()
+	koolStart := newFakeKoolStart()
 
 	cmd := NewStartCommand(koolStart)
 
@@ -56,7 +56,7 @@ func TestStartAllCommand(t *testing.T) {
 }
 
 func TestStartForegroundFlag(t *testing.T) {
-	koolStart := newMockStart()
+	koolStart := newFakeKoolStart()
 
 	if err := koolStart.Execute(nil); err != nil {
 		t.Fatal(err)
@@ -67,7 +67,7 @@ func TestStartForegroundFlag(t *testing.T) {
 		t.Error("did not set -d on start")
 	}
 
-	koolStart = newMockStart()
+	koolStart = newFakeKoolStart()
 	koolStart.Flags.Foreground = true
 
 	if err := koolStart.Execute(nil); err != nil {
@@ -81,7 +81,7 @@ func TestStartForegroundFlag(t *testing.T) {
 }
 
 func TestStartRebuildFlag(t *testing.T) {
-	koolStart := newMockStart()
+	koolStart := newFakeKoolStart()
 
 	if err := koolStart.Execute(nil); err != nil {
 		t.Fatal(err)
@@ -92,7 +92,7 @@ func TestStartRebuildFlag(t *testing.T) {
 		t.Error("should not have executed pull or build")
 	}
 
-	koolStart = newMockStart()
+	koolStart = newFakeKoolStart()
 	rebuilder = koolStart.rebuilder.(*KoolRebuild)
 
 	koolStart.Flags.Rebuild = true
@@ -109,7 +109,7 @@ func TestStartRebuildFlag(t *testing.T) {
 }
 
 func TestStartServicesCommand(t *testing.T) {
-	koolStart := newMockStart()
+	koolStart := newFakeKoolStart()
 
 	cmd := NewStartCommand(koolStart)
 	expected := []string{"app", "database"}
@@ -133,7 +133,7 @@ func TestStartServicesCommand(t *testing.T) {
 }
 
 func TestFailedDependenciesStartCommand(t *testing.T) {
-	koolStart := newMockStart()
+	koolStart := newFakeKoolStart()
 	koolStart.check.(*checker.FakeChecker).MockError = errors.New("dependencies")
 
 	cmd := NewStartCommand(koolStart)
@@ -150,7 +150,7 @@ func TestFailedDependenciesStartCommand(t *testing.T) {
 }
 
 func TestFailedNetworkStartCommand(t *testing.T) {
-	koolStart := newMockStart()
+	koolStart := newFakeKoolStart()
 	koolStart.net.(*network.FakeHandler).MockError = errors.New("network")
 
 	cmd := NewStartCommand(koolStart)
@@ -167,7 +167,7 @@ func TestFailedNetworkStartCommand(t *testing.T) {
 }
 
 func TestStartWithError(t *testing.T) {
-	koolStart := newMockStart()
+	koolStart := newFakeKoolStart()
 	koolStart.start.(*builder.FakeCommand).MockInteractiveError = errors.New("start")
 
 	cmd := NewStartCommand(koolStart)

--- a/docs/4-Commands/kool-restart.md
+++ b/docs/4-Commands/kool-restart.md
@@ -9,8 +9,9 @@ kool restart
 ### Options
 
 ```
-  -h, --help    help for restart
-      --purge   Remove all persistent data from volume mounts on containers
+  -h, --help      help for restart
+      --purge     Remove all persistent data from volume mounts on containers
+      --rebuild   Updates and builds service's images
 ```
 
 ### Options inherited from parent commands

--- a/docs/4-Commands/kool-start.md
+++ b/docs/4-Commands/kool-start.md
@@ -16,6 +16,7 @@ kool start [SERVICE...]
 ```
   -f, --foreground   Start containers in foreground mode
   -h, --help         help for start
+  -b, --rebuild      Updates and builds service's images
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | https://github.com/kool-dev/kool/issues/349 |
| -----: | :-----: |
| :trophy: Feature | Yes |
| :open_book: Documentation | Yes |
| :warning: Break Change | No |

**Description**

Adding a new flag `--rebuild` to both `kool start` and `kool restart` for updating the services images (`docker-compose pull` and `docker-compose build --pull`).
