### PR TITLE
Use Docker Image for Hugo Extended Version

### DIFF
--- a/core/presets/configs.go
+++ b/core/presets/configs.go
@@ -51,7 +51,7 @@ templates:
 	configs["hugo"] = `language: static
 commands:
   create:
-  - kool docker klakegg/hugo new site $CREATE_DIRECTORY
+  - kool docker klakegg/hugo:ext-alpine new site $CREATE_DIRECTORY
 `
 	configs["laravel"] = `language: php
 commands:

--- a/core/presets/presets.go
+++ b/core/presets/presets.go
@@ -29,7 +29,7 @@ func GetAll() map[string]map[string]string {
 		"docker-compose.yml": `version: "3.8"
 services:
   app:
-    image: klakegg/hugo
+    image: klakegg/hugo:ext-alpine
     command: ["server", "-p", "80", "-D"]
     working_dir: /app
     ports:
@@ -53,7 +53,7 @@ networks:
     name: "${KOOL_GLOBAL_NETWORK:-kool_global}"
 `,
 		"kool.yml": `scripts:
-  hugo: kool docker -p 1313:1313 klakegg/hugo
+  hugo: kool docker -p 1313:1313 klakegg/hugo:ext-alpine
   dev: kool run hugo server -D
 
   # remove or modify to suit the needs of your project

--- a/docs/2-Presets/Hugo.md
+++ b/docs/2-Presets/Hugo.md
@@ -27,7 +27,7 @@ Use the [`kool create PRESET FOLDER` command](/docs/commands/kool-create) to cre
 $ kool create hugo my-project
 ```
 
-Under the hood, this command will run `kool docker klakegg/hugo new site my-project` using the [klakegg/hugo](https://hub.docker.com/r/klakegg/hugo/) Docker image.
+Under the hood, this command will run `kool docker klakegg/hugo:ext-alpine new site my-project` using the [klakegg/hugo](https://hub.docker.com/r/klakegg/hugo/) Docker image.
 
 Now, move into your new Hugo project:
 
@@ -54,7 +54,7 @@ To help get you started, **kool.yml** comes prebuilt with an initial set of scri
 
 ```yaml
 scripts:
-	hugo: kool docker -p 1313:1313 klakegg/hugo
+	hugo: kool docker -p 1313:1313 klakegg/hugo:ext-alpine
 	dev: kool run hugo server -D
 
 	# remove or modify to suit the needs of your project

--- a/presets/hugo/docker-compose.yml
+++ b/presets/hugo/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   app:
-    image: klakegg/hugo
+    image: klakegg/hugo:ext-alpine
     command: ["server", "-p", "80", "-D"]
     working_dir: /app
     ports:

--- a/presets/hugo/kool.yml
+++ b/presets/hugo/kool.yml
@@ -1,5 +1,5 @@
 scripts:
-  hugo: kool docker -p 1313:1313 klakegg/hugo
+  hugo: kool docker -p 1313:1313 klakegg/hugo:ext-alpine
   dev: kool run hugo server -D
 
   # remove or modify to suit the needs of your project

--- a/presets/hugo/preset-config.yml
+++ b/presets/hugo/preset-config.yml
@@ -1,4 +1,4 @@
 language: static
 commands:
   create:
-  - kool docker klakegg/hugo new site $CREATE_DIRECTORY
+  - kool docker klakegg/hugo:ext-alpine new site $CREATE_DIRECTORY


### PR DESCRIPTION
| Issue | # |
| -----: | :-----: |
| :beetle: Bug Fix | Yes |
| :pencil: Refactor | Yes |

**Description**

After writing a new Hugo blog post and testing the steps, I encountered a new error when the `kool run quickstart` script attempted to build the Ananke theme: "Check your Hugo installation; you need the extended version to build SCSS/SASS." To fix, I changed the Hugo Docker image to use the Extended version of Hugo (`hugo:ext-alpine`).

Also updated the Hugo Preset docs page accordingly.
