### PR TITLE
auto updater - check write permission

### DIFF
--- a/commands/info.go
+++ b/commands/info.go
@@ -14,7 +14,7 @@ import (
 type KoolInfo struct {
 	DefaultKoolService
 
-	envStorage environment.EnvStorage
+	envStorage                  environment.EnvStorage
 	cmdDocker, cmdDockerCompose builder.Command
 }
 

--- a/services/updater/updater.go
+++ b/services/updater/updater.go
@@ -80,22 +80,24 @@ func (u *DefaultUpdater) CheckPermission() (err error) {
 		return
 	}
 
-	var (
-		binPath string
-	)
+	if runtime.GOOS == "linux" {
+		var (
+			binPath string
+		)
 
-	if binPath, err = os.Executable(); err != nil {
-		return
-	}
+		if binPath, err = os.Executable(); err != nil {
+			return
+		}
 
-	if binPath, err = filepath.EvalSymlinks(binPath); err != nil {
-		return
-	}
+		if binPath, err = filepath.EvalSymlinks(binPath); err != nil {
+			return
+		}
 
-	if unix.Access(binPath, unix.W_OK) == nil && unix.Access(filepath.Dir(binPath), unix.W_OK) == nil {
-		// the folder the binary file lives is IS writeable
-		// for the current user
-		return
+		if unix.Access(binPath, unix.W_OK) == nil && unix.Access(filepath.Dir(binPath), unix.W_OK) == nil {
+			// the folder the binary file lives is IS writeable
+			// for the current user
+			return
+		}
 	}
 
 	// we need elevated privileges!

--- a/services/updater/updater.go
+++ b/services/updater/updater.go
@@ -10,7 +10,6 @@ import (
 	"github.com/blang/semver"
 	"github.com/rhysd/go-github-selfupdate/selfupdate"
 	"github.com/spf13/cobra"
-	"golang.org/x/sys/unix"
 )
 
 // DefaultUpdater holds data for updating kool
@@ -93,7 +92,7 @@ func (u *DefaultUpdater) CheckPermission() (err error) {
 			return
 		}
 
-		if unix.Access(binPath, unix.W_OK) == nil && unix.Access(filepath.Dir(binPath), unix.W_OK) == nil {
+		if isWriteable(binPath) && isWriteable(filepath.Dir(binPath)) {
 			// the folder the binary file lives is IS writeable
 			// for the current user
 			return

--- a/services/updater/updater.go
+++ b/services/updater/updater.go
@@ -3,11 +3,14 @@ package updater
 import (
 	"fmt"
 	"kool-dev/kool/services/user"
+	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/blang/semver"
 	"github.com/rhysd/go-github-selfupdate/selfupdate"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 )
 
 // DefaultUpdater holds data for updating kool
@@ -74,6 +77,24 @@ func (u *DefaultUpdater) CheckForUpdates(current semver.Version, chHasNewVersion
 func (u *DefaultUpdater) CheckPermission() (err error) {
 	if runtime.GOOS != "windows" && runtime.GOOS != "linux" {
 		// we should be fine in other plataforms, permission-wise
+		return
+	}
+
+	var (
+		binPath string
+	)
+
+	if binPath, err = os.Executable(); err != nil {
+		return
+	}
+
+	if binPath, err = filepath.EvalSymlinks(binPath); err != nil {
+		return
+	}
+
+	if unix.Access(binPath, unix.W_OK) == nil && unix.Access(filepath.Dir(binPath), unix.W_OK) == nil {
+		// the folder the binary file lives is IS writeable
+		// for the current user
 		return
 	}
 

--- a/services/updater/writeable.go
+++ b/services/updater/writeable.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package updater
+
+import "fmt"
+
+func isWriteable(path string) bool {
+	fmt.Println("called unimplemented updater.isWriteable")
+
+	return false
+}

--- a/services/updater/writeable_linux.go
+++ b/services/updater/writeable_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package updater
+
+import "golang.org/x/sys/unix"
+
+func isWriteable(path string) bool {
+	return unix.Access(path, unix.W_OK) == nil
+}

--- a/services/user/elevated.go
+++ b/services/user/elevated.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package user
 


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | https://github.com/kool-dev/kool/issues/366 |
| -----: | :-----: |
| :beetle: Bug Fix | Yes |
| :trophy: Feature | Yes |
| :warning: Break Change | No |

**Description**

The `self-update` command won't ask for elevated user permissions when the binary folder is already writeable by the current user.

---

**Notes**

- This has not been tested on Windows.
