### PR TITLE
fix error message when attemptig exec on unstarted container

### DIFF
--- a/commands/exec.go
+++ b/commands/exec.go
@@ -89,7 +89,7 @@ func (e *KoolExec) checkUser(service string) {
 		defer e.Shell().SetOutStream(actualOut)
 
 		e.Shell().SetOutStream(os.Stderr)
-		e.Shell().Warning("failed to check running container for kool user; not setting a user (err: %s)", err.Error())
+		e.Shell().Warning(fmt.Sprintf("failed to check running container for kool user; did you forget kool start? (err: %s)", err.Error()))
 	} else if strings.Contains(passwd, fmt.Sprintf("kool:x:%s", asuser)) {
 		// since user (kool:x:UID) exists within the container, we set it
 		e.composeExec.AppendArgs("--user", asuser)


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | # |
| -----: | :-----: |
| :beetle: Bug Fix | Yes|
| :warning: Break Change | No |

**Description**

Fixes formatting and improves error message when trying to execute before starting containers.

