### PR TITLE
improve error message on script called without the 'run' command

### DIFF
--- a/commands/kool_upgrade_available_checker.go
+++ b/commands/kool_upgrade_available_checker.go
@@ -11,19 +11,21 @@ type UpdateAwareService struct {
 	KoolService
 
 	updater updater.Updater
+	skip    bool
 }
 
 // CheckNewVersion wraps the service with checker logic
-func CheckNewVersion(service KoolService, updater updater.Updater) *UpdateAwareService {
+func CheckNewVersion(service KoolService, updater updater.Updater, skip bool) *UpdateAwareService {
 	return &UpdateAwareService{
 		service,
 		updater,
+		skip,
 	}
 }
 
 // Execute runs the check logic and proxies to original service
 func (u *UpdateAwareService) Execute(args []string) (err error) {
-	if !u.KoolService.Shell().IsTerminal() {
+	if u.skip || !u.KoolService.Shell().IsTerminal() {
 		err = u.KoolService.Execute(args)
 		return
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -6,6 +6,7 @@ import (
 	"kool-dev/kool/core/environment"
 	"kool-dev/kool/core/parser"
 	"kool-dev/kool/core/shell"
+	"path"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -83,9 +84,13 @@ Complete documentation is available at https://kool.dev/docs`,
 			}
 
 			scriptParser := parser.NewParser()
+			env := environment.NewEnvStorage()
 
 			// look for kool.yml on current working directory
-			_ = scriptParser.AddLookupPath(environment.NewEnvStorage().Get("PWD"))
+			_ = scriptParser.AddLookupPath(env.Get("PWD"))
+			// look for kool.yml on kool folder within user home directory
+			_ = scriptParser.AddLookupPath(path.Join(env.Get("HOME"), "kool"))
+
 			_, err = scriptParser.Parse(args[0])
 
 			if err == nil {

--- a/commands/start.go
+++ b/commands/start.go
@@ -46,7 +46,7 @@ func NewStartCommand(start *KoolStart) (startCmd *cobra.Command) {
 		Short:      "Start service containers defined in docker-compose.yml",
 		Long: `Start one or more specified [SERVICE] containers. If no [SERVICE] is provided,
 all containers are started. If the containers are already running, they are recreated.`,
-		RunE: DefaultCommandRunFunction(CheckNewVersion(start, &updater.DefaultUpdater{RootCommand: rootCmd})),
+		RunE: DefaultCommandRunFunction(CheckNewVersion(start, &updater.DefaultUpdater{RootCommand: rootCmd}, version == DEV_VERSION)),
 
 		DisableFlagsInUseLine: true,
 	}

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -92,7 +92,7 @@ func NewStopCommand(stop *KoolStop) (stopCmd *cobra.Command) {
 		Short:      "Stop and destroy running service containers",
 		Long: `Stop and destroy the specified [SERVICE] containers, which were started
 using 'kool start'. If no [SERVICE] is provided, all running containers are stopped.`,
-		RunE: LongTaskCommandRunFunction(task),
+		RunE: DefaultCommandRunFunction(task),
 
 		DisableFlagsInUseLine: true,
 	}


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | - |
| -----: | :-----: |
| :trophy: Feature | Yes |
| :warning: Break Change | No |

**Description**

This PR generates a more helpful error message when trying to run what could be a script from `kool run foo` as simply `kool foo`.

