### PR TITLE
update: better error message for sudo requirement on self-update

### DIFF
--- a/commands/self-update.go
+++ b/commands/self-update.go
@@ -43,8 +43,10 @@ func (s *KoolSelfUpdate) Execute(args []string) (err error) {
 	currentVersion = s.updater.GetCurrentVersion()
 
 	if latestVersion, err = s.updater.Update(currentVersion); err != nil {
-		if strings.Contains(err.Error(), "permission denied") {
-			return fmt.Errorf("kool self-update failed: %v (maybe try again with sudo)", err)
+		if strings.Contains(strings.ToLower(err.Error()), "permission denied") {
+			s.Shell().Warning("Error: %s", err)
+
+			return fmt.Errorf("kool self-update failed: (maybe try again with sudo)")
 		}
 		return fmt.Errorf("kool self-update failed: %v", err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | #410   |
| -----: | :-----: |
| :warning: Break Change | No |

**Description**

Improving a bit the error message to indicate the need of running `self-update` with `sudo`.
