### PR TITLE
Created documentation for net::ERR_EMPTY_RESPONSE issue in Laravel Mix\Laravel Vite

### DIFF
--- a/docs/6-Troubleshooting/hmr-eer-empty-response.md
+++ b/docs/6-Troubleshooting/hmr-eer-empty-response.md
@@ -1,5 +1,7 @@
 ### `kool run npm run hot` or `kool run npm run dev`
 
+> Also valid for `kool run yarn run hot` or `kool run yarn run dev`
+
 **Problem:**
 
 > Browser cannot request "HMR" (hot module replacement) server successfully in Laravel Mix or Laravel Vite.

--- a/docs/6-Troubleshooting/hmr-eer-empty-response.md
+++ b/docs/6-Troubleshooting/hmr-eer-empty-response.md
@@ -1,0 +1,54 @@
+### `kool run npm run hot` or `kool run npm run dev`
+
+**Problem:**
+
+> Browser cannot request "HMR" (hot module replacement) server successfully in Laravel Mix or Laravel Vite.
+
+> Console errors: **net::ERR_CONNECTION_REFUSED** or **net::ERR_EMPTY_RESPONSE**.
+
+**Answer:**
+
+> Publish the HMR's port to the host and change HMR settings to listen on all IPv4 addresses (`0.0.0.0`).
+
+For the sake of clarity, let's elect port `8080` to publish.
+
+In your `kool.yml`, apply the following changes:
+
+```diff
+-npm: kool docker kooldev/node:16 npm
++npm: kool docker -p 8080:8080 kooldev/node:16 npm
+```
+
+- Alternatively, if you don't want to publish the port for your general `kool run npm` commands, you may add a new entry.
+
+**> Laravel Mix**
+
+In your `webpack.mix.js`, include the following changes to the `mix.options` call.
+
+```diff
+mix.options({
++    hmrOptions: {
++        host: '0.0.0.0',
++        port: 8080,
++    },
+});
+```
+
+**> Laravel Vite**
+
+In your `vite.config.js` file, include the following changes to the `defineConfig` call.
+
+```diff
+export default defineConfig({
++    server: {
++        host: '0.0.0.0',
++        port: 8080,
++    },
+    plugins: [
+        laravel({
+            input: ['resources/css/app.css', 'resources/js/app.js'],
+            refresh: true,
+        }),
+    ],
+});
+```


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | # |
| -----: | :-----: |
| :beetle: Bug Fix | No |
| :toolbox: Improvement | No |
| :trophy: Feature | No |
| :pencil: Refactor | No |
| :x: Removed | No |
| :open_book: Documentation | Yes |
| :warning: Break Change | No |

# Description
Created documentation for the setting of Laravel Mix/Laravel Vite, getting rid of `net::ERR_EMPTY_RESPONSE` issue

# Steps to reproduce
1. `kool create laravel my-test-application`
2. For the presets, choose: PHP 8.1, MySQL 8.0, none for Cache, npm for assets.
3. `kool run setup`
4. Find `welcome.blade.php`, add `@vite('resources/js/app.js')` to the `< head >`
5. Access `localhost` in the browser, open dev-tools, check console error 

![image](https://user-images.githubusercontent.com/5265316/190025685-e86bb8a1-aa5b-44ec-8194-5350e249476e.png)


EDIT:
This looks like a very secure Pull Request
![image](https://user-images.githubusercontent.com/5265316/190026109-b82961c5-ec90-4e73-89e8-5fbb2dab5d71.png)

