### PR TITLE
fix install aarch64 -> arm64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,10 @@ do_install () {
 		ARCH="amd64"
 	fi
 
+	if [ "$ARCH" == "aarch64" ]; then
+		ARCH="arm64"
+	fi
+
 	echo "Downloading latest binary (kool-$PLAT-$ARCH)..."
 
 	# TODO: fallback to wget if no curl available


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | # |
| -----: | :-----: |
| :beetle: Bug Fix | Yes |
| :toolbox: Improvement | Yes |
| :warning: Break Change | No |

**Description**

Fixes the install script telling for Linux `$(uname -m)` arch, fetching the proper ARM64 binary.

