### PR TITLE
Fixing PhpUnit Default Folder

### DIFF
--- a/templates/scripts/laravel+octane+roadrunner.yml
+++ b/templates/scripts/laravel+octane+roadrunner.yml
@@ -1,7 +1,7 @@
 scripts:
   composer: kool exec app composer
   artisan: kool exec app php artisan
-  phpunit: kool exec app php ./bin/phpunit
+  phpunit: kool exec app php ./vendor/bin/phpunit
 
   setup:
     - kool run before-start

--- a/templates/scripts/laravel+octane+swoole.yml
+++ b/templates/scripts/laravel+octane+swoole.yml
@@ -1,7 +1,7 @@
 scripts:
   composer: kool exec app composer
   artisan: kool exec app php artisan
-  phpunit: kool exec app php ./bin/phpunit
+  phpunit: kool exec app php ./vendor/bin/phpunit
 
   setup:
     - kool run before-start

--- a/templates/scripts/laravel.yml
+++ b/templates/scripts/laravel.yml
@@ -1,7 +1,7 @@
 scripts:
   composer: kool exec app composer
   artisan: kool exec app php artisan
-  phpunit: kool exec app php ./bin/phpunit
+  phpunit: kool exec app php ./vendor/bin/phpunit
 
   setup:
     - kool run before-start


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | # |
| -----: | :-----: |
| :beetle: Bug Fix |Yes |
| :toolbox: Improvement | No/Yes |
| :trophy: Feature | No/Yes |
| :pencil: Refactor | No/Yes |
| :x: Removed | No/Yes |
| :open_book: Documentation | No/Yes |
| :warning: Break Change | No/Yes |

**Description**
<!-- descriptive text on the changes made -->

This PR aims to fix the PhpUnit default folder from: `./bin/phpunit` to `./vendor/bin/phpunit` which is the correct one.
