### PR TITLE
`kool start` error message improv + verbose output improvement

### DIFF
--- a/commands/start.go
+++ b/commands/start.go
@@ -1,11 +1,13 @@
 package commands
 
 import (
+	"fmt"
 	"kool-dev/kool/core/builder"
 	"kool-dev/kool/core/environment"
 	"kool-dev/kool/core/network"
 	"kool-dev/kool/services/checker"
 	"kool-dev/kool/services/updater"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -107,6 +109,9 @@ func (s *KoolStart) Execute(args []string) (err error) {
 	}
 
 	if err = s.checkDependencies(); err != nil {
+		if strings.HasPrefix(err.Error(), "no configuration file provided: not found") {
+			err = fmt.Errorf("could not find docker-compose.yml - check your current working directory.\n\n[err: %v]", err)
+		}
 		return
 	}
 

--- a/core/shell/shell.go
+++ b/core/shell/shell.go
@@ -174,11 +174,11 @@ func (s *DefaultShell) Interactive(originalCmd builder.Command, extraArgs ...str
 
 	if verbose {
 		checker := NewTerminalChecker()
-		fmt.Fprintf(s.ErrStream(), "$ (TTY in: %v out: %v) %s %v\n",
+		fmt.Fprintf(s.ErrStream(), "$ (TTY in: %v out: %v) %s %s\n",
 			checker.IsTerminal(cmdptr.in),
 			checker.IsTerminal(cmdptr.out),
 			cmdptr.Command.Cmd(),
-			cmdptr.Command.Args(),
+			strings.Join(cmdptr.Command.Args(), " "),
 		)
 	}
 

--- a/core/shell/shell.go
+++ b/core/shell/shell.go
@@ -136,9 +136,9 @@ func (s *DefaultShell) Exec(command builder.Command, extraArgs ...string) (outSt
 	}
 
 	if verbose {
-		fmt.Fprintf(s.ErrStream(), "$ (exec) %s %v\n",
+		fmt.Fprintf(s.ErrStream(), "$ (exec) %s %s\n",
 			exe,
-			args,
+			strings.Join(args, " "),
 		)
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | https://github.com/kool-dev/kool/issues/279 |
| -----: | :-----: |
| :toolbox: Improvement | Yes |
| :open_book: Documentation | No |
| :warning: Break Change | No |

**Description**

- `kool start` - improved error message when no docker-compose.yml or else designated docker compose config file not found in the current working dir;
- improve the output of actual commands when using `--verbose`

Notes

- Other suggestions on the ticket don't seem to be worth the trade-off at this point - because handling more errors would mean wrapping the output file pointers to some sort of buffer to be able to check it later, but that would cause for losing TTY capacity when using interactive - something we don't want.