### PR TITLE
add helper url to follow deploy logs on the web panel

### DIFF
--- a/commands/cloud_deploy.go
+++ b/commands/cloud_deploy.go
@@ -118,6 +118,12 @@ func (d *KoolDeploy) Execute(args []string) (err error) {
 		}
 	}
 
+	if deployCreated.LogsUrl != "" {
+		d.Shell().Info(strings.Repeat("-", 40))
+		d.Shell().Info("Logs available at: ", deployCreated.LogsUrl)
+		d.Shell().Info(strings.Repeat("-", 40))
+	}
+
 	s = utils.MakeFastLoading("Start deploying...", "Deploy started.", d.Shell().OutStream())
 	if _, err = deployer.StartDeploy(deployCreated); err != nil {
 		return

--- a/services/cloud/api/deploy_create.go
+++ b/services/cloud/api/deploy_create.go
@@ -25,6 +25,8 @@ type DeployCreateResponse struct {
 		Login    string `json:"login"`
 		Password string `json:"password"`
 	} `json:"docker"`
+
+	LogsUrl string `json:"logs_url"`
 }
 
 // DeployCreate consumes the API endpoint to create a new deployment


### PR DESCRIPTION
| Issue | - |
| -----: | :-----: |
| :toolbox: Improvement | Yes |
| :warning: Break Change | No |

**Description**

Includes a helper URL for users deploying to follow logs on the web panel.