### PR TITLE
specifcy build to use linux/amd64 for deployment

### DIFF
--- a/services/cloud/build.go
+++ b/services/cloud/build.go
@@ -32,7 +32,7 @@ func BuildPushImageForDeploy(service string, config *DeployConfigService, deploy
 	var in = bytes.NewBuffer([]byte{})
 	sh.SetInStream(in)
 
-	dockerBuild := builder.NewCommand("docker", "build", "-t", image)
+	dockerBuild := builder.NewCommand("docker", "build", "-t", image, "--platform", "linux/amd64")
 
 	if folder, isStr := (*config.Build).(string); isStr {
 		// this should be a simple build with a context folder


### PR DESCRIPTION
| Issue | - |
| -----: | :-----: |
| :beetle: Bug Fix | Yes |
| :warning: Break Change | No |

**Description**

Explicitly set platform `linux/amd64` for deploy images being built.

