### PR TITLE
add wget fallback in installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,9 +40,17 @@ do_install () {
 
 	echo "Downloading latest binary (kool-$PLAT-$ARCH)..."
 
-	# TODO: fallback to wget if no curl available
-	rm -f /tmp/kool_binary
-	curl -fsSL "$DOWNLOAD_URL/kool-$PLAT-$ARCH" -o /tmp/kool_binary
+    rm -f /tmp/kool_binary
+	
+	# fallback to wget if no curl available
+    if command -v curl &> /dev/null; then
+        curl -fsSL "$DOWNLOAD_URL/kool-$PLAT-$ARCH" -o /tmp/kool_binary
+    elif command -v wget &> /dev/null; then
+        wget -qO /tmp/kool_binary "$DOWNLOAD_URL/kool-$PLAT-$ARCH"
+    else
+        echo -e "\033[31;31mError: Neither curl nor wget is available. Please install one of them to proceed.\033[0m"
+        exit 1
+    fi
 
 	# check for running kool process which would prevent
 	# replacing existing version under Linux.


### PR DESCRIPTION
<!--
Thank you for contributing through this Pull Request!

- Please link to the issue at hand. If the subject in question has no associated issue, please consider opening one for history tracking.
- Please provide a clear and objective description of the work done.
- Make sure the PR **passes** all CI checks. Code changes should have respective tests added.
-->

| Issue | # |
| -----: | :-----: |
| :beetle: Bug Fix | No |
| :toolbox: Improvement | Yes |
| :trophy: Feature | No |
| :pencil: Refactor | No |
| :x: Removed | No |
| :open_book: Documentation | No |
| :warning: Break Change | No |

**Description**
Add a wget fallback option to the curl in `install.sh` script, solves #517
