### PR TITLE
fix: replace string match with regex for Compose version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,11 +85,13 @@ do_install () {
 	fi
 
 	composeVersion=$(docker compose version || true)
-	if [[ ! "$composeVersion" == *"Docker Compose version v2"* ]]; then
-		builtin echo -e "${start_error}We could not identify Composer V2 installed.${end_error}"
-		builtin echo -e "Please make sure you are running an updated Docker version that includes Compose V2:"
+  regex="Docker Compose version v?([25]|[1-9][0-9]+)\."
+
+	if [[ ! "$composeVersion" =~ $regex ]]; then
+		builtin echo -e "${start_error}We could not identify a valid Composer version installed.${end_error}"
+		builtin echo -e "Please make sure you are running an updated Docker version that includes Compose V2 or V5:"
 		builtin echo -e "  Official Docker installation documentation: https://docs.docker.com/get-docker/"
-		builtin echo -e "  Official Docker Compose V2 documentation: https://docs.docker.com/compose/reference/"
+		builtin echo -e "  Official Docker Compose documentation: https://docs.docker.com/compose/reference/"
 		exit
 	fi
 


### PR DESCRIPTION
| Issue | #528 |
| -----: | :-----: |
| :beetle: Bug Fix | Yes |
| :toolbox: Improvement | Yes |

**Description**
---
Use a regex-based check for Docker Compose version detection in the installation script, making the 'v' prefix optional and allowing versions 2, 5, and 10+.
